### PR TITLE
fix: error boundary, fire-and-forget bugs, config cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",
     "express": "^5.2.1",
-    "svelte": "^5.53.0"
+    "svelte": "^5.53.0",
+    "svelte-codemirror-editor": "^2.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.2",
@@ -93,7 +94,6 @@
     "lint-staged": "^16.2.7",
     "storybook": "^10.2.10",
     "supertest": "^7.2.2",
-    "svelte-codemirror-editor": "^2.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^6.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       svelte:
         specifier: ^5.53.0
         version: 5.53.0
+      svelte-codemirror-editor:
+        specifier: ^2.1.0
+        version: 2.1.0(codemirror@6.0.2)(svelte@5.53.0)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.2
@@ -129,9 +132,6 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
-      svelte-codemirror-editor:
-        specifier: ^2.1.0
-        version: 2.1.0(codemirror@6.0.2)(svelte@5.53.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
-onlyBuiltDependencies: '["better-sqlite3", "esbuild"]'
+onlyBuiltDependencies:
+  - better-sqlite3
+  - esbuild

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -300,7 +300,10 @@ export function apiCreateWritingSample(filename: string | null, domain: string, 
 }
 
 export async function apiDeleteWritingSample(id: string): Promise<void> {
-  await fetch(`${BASE}/writing-samples/${id}`, { method: "DELETE" });
+  const res = await fetch(`${BASE}/writing-samples/${id}`, { method: "DELETE" });
+  if (!res.ok) {
+    throw new Error(`Failed to delete writing sample: ${res.status}`);
+  }
 }
 
 // ─── Project Voice Learning ─────────────────────────

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -302,7 +302,8 @@ export function apiCreateWritingSample(filename: string | null, domain: string, 
 export async function apiDeleteWritingSample(id: string): Promise<void> {
   const res = await fetch(`${BASE}/writing-samples/${id}`, { method: "DELETE" });
   if (!res.ok) {
-    throw new Error(`Failed to delete writing sample: ${res.status}`);
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(`Failed to delete writing sample: ${(body as { error: string }).error}`);
   }
 }
 

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -427,7 +427,7 @@ function exportState() {
         <div class="stage-crash">
           <h3>Something went wrong</h3>
           <p>{err instanceof Error ? err.message : "An unexpected error occurred."}</p>
-          <Button onclick={reset}>Try Again</Button>
+          <Button onclick={() => { store.setError(null); reset(); }}>Try Again</Button>
         </div>
       {/snippet}
     </svelte:boundary>

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -382,8 +382,8 @@ function exportState() {
   <StageCTA nextStage={workflow.nextStageCTA} onclick={(stage) => workflow.goToStage(stage.id)} />
 
   <div class="stage-workspace">
-    <svelte:boundary onerror={(err) => { console.error("[boundary] Stage crash:", err); store.setError(`Something went wrong: ${err instanceof Error ? err.message : "Unknown error"}. Try switching stages or refreshing.`); }}>
-      {#key workflow.activeStage}
+    {#key workflow.activeStage}
+      <svelte:boundary onerror={(err) => { console.error("[boundary] Stage crash:", err); store.setError(`Something went wrong: ${err instanceof Error ? err.message : "Unknown error"}. Try switching stages or refreshing.`); }}>
         <div class="stage-content" in:fade={{ duration: 150, delay: 50 }} out:fade={{ duration: 100 }}>
           {#if workflow.activeStage === "bootstrap"}
             <BootstrapStage {store} {commands} />
@@ -422,15 +422,15 @@ function exportState() {
             <ExportStage {store} />
           {/if}
         </div>
-      {/key}
-      {#snippet failed(err, reset)}
-        <div class="stage-crash">
-          <h3>Something went wrong</h3>
-          <p>{err instanceof Error ? err.message : "An unexpected error occurred."}</p>
-          <Button onclick={() => { store.setError(null); reset(); }}>Try Again</Button>
-        </div>
-      {/snippet}
-    </svelte:boundary>
+        {#snippet failed(err, reset)}
+          <div class="stage-crash">
+            <h3>Something went wrong</h3>
+            <p>{err instanceof Error ? err.message : "An unexpected error occurred."}</p>
+            <Button onclick={() => { store.setError(null); reset(); }}>Try Again</Button>
+          </div>
+        {/snippet}
+      </svelte:boundary>
+    {/key}
   </div>
 
   <GlossaryPanel />

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -166,6 +166,7 @@ function handleBackToProjects() {
 let newProjectTitle = $state("");
 let editingTitle = $state(false);
 let editTitleValue = $state("");
+let boundaryErrorMsg = "";
 
 // ─── Prose word count ───────────────────────────
 let totalWordCount = $derived(
@@ -383,7 +384,7 @@ function exportState() {
 
   <div class="stage-workspace">
     {#key workflow.activeStage}
-      <svelte:boundary onerror={(err) => { console.error("[boundary] Stage crash:", err); store.setError(`Something went wrong: ${err instanceof Error ? err.message : "Unknown error"}. Try switching stages or refreshing.`); }}>
+      <svelte:boundary onerror={(err) => { console.error("[boundary] Stage crash:", err); boundaryErrorMsg = `Something went wrong: ${err instanceof Error ? err.message : "Unknown error"}. Try switching stages or refreshing.`; store.setError(boundaryErrorMsg); }}>
         <div class="stage-content" in:fade={{ duration: 150, delay: 50 }} out:fade={{ duration: 100 }}>
           {#if workflow.activeStage === "bootstrap"}
             <BootstrapStage {store} {commands} />
@@ -426,7 +427,7 @@ function exportState() {
           <div class="stage-crash">
             <h3>Something went wrong</h3>
             <p>{err instanceof Error ? err.message : "An unexpected error occurred."}</p>
-            <Button onclick={() => { store.setError(null); reset(); }}>Try Again</Button>
+            <Button onclick={() => { if (store.error === boundaryErrorMsg) store.setError(null); reset(); }}>Try Again</Button>
           </div>
         {/snippet}
       </svelte:boundary>

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -382,46 +382,55 @@ function exportState() {
   <StageCTA nextStage={workflow.nextStageCTA} onclick={(stage) => workflow.goToStage(stage.id)} />
 
   <div class="stage-workspace">
-    {#key workflow.activeStage}
-      <div class="stage-content" in:fade={{ duration: 150, delay: 50 }} out:fade={{ duration: 100 }}>
-        {#if workflow.activeStage === "bootstrap"}
-          <BootstrapStage {store} {commands} />
-        {:else if workflow.activeStage === "draft"}
-          <DraftStage
-            {store}
-            {commands}
-            onGenerate={() => generateChunk()}
-            onRunAudit={() => runAuditManual()}
-            onRunDeepAudit={() => runDeepAudit()}
-            onAutopilot={() => runAutopilot()}
-            onExtractIR={(sceneId) => extractSceneIR(sceneId)}
-          />
-        {:else if workflow.activeStage === "plan"}
-          <PlanStage {store} {commands} />
-        {:else if workflow.activeStage === "audit"}
-          <AuditStage
-            {store}
-            {commands}
-            onRunAudit={() => runAuditManual()}
-            onRunDeepAudit={() => runDeepAudit()}
-          />
-        {:else if workflow.activeStage === "edit"}
-          <EditStage
-            {store}
-            {commands}
-            onRequestRefinement={requestRefinement}
-          />
-        {:else if workflow.activeStage === "complete"}
-          <CompleteStage
-            {store}
-            {commands}
-            onExtractIR={(sceneId) => extractSceneIR(sceneId)}
-          />
-        {:else if workflow.activeStage === "export"}
-          <ExportStage {store} />
-        {/if}
-      </div>
-    {/key}
+    <svelte:boundary onerror={(err) => { console.error("[boundary] Stage crash:", err); store.setError(`Something went wrong: ${err instanceof Error ? err.message : "Unknown error"}. Try switching stages or refreshing.`); }}>
+      {#key workflow.activeStage}
+        <div class="stage-content" in:fade={{ duration: 150, delay: 50 }} out:fade={{ duration: 100 }}>
+          {#if workflow.activeStage === "bootstrap"}
+            <BootstrapStage {store} {commands} />
+          {:else if workflow.activeStage === "draft"}
+            <DraftStage
+              {store}
+              {commands}
+              onGenerate={() => generateChunk()}
+              onRunAudit={() => runAuditManual()}
+              onRunDeepAudit={() => runDeepAudit()}
+              onAutopilot={() => runAutopilot()}
+              onExtractIR={(sceneId) => extractSceneIR(sceneId)}
+            />
+          {:else if workflow.activeStage === "plan"}
+            <PlanStage {store} {commands} />
+          {:else if workflow.activeStage === "audit"}
+            <AuditStage
+              {store}
+              {commands}
+              onRunAudit={() => runAuditManual()}
+              onRunDeepAudit={() => runDeepAudit()}
+            />
+          {:else if workflow.activeStage === "edit"}
+            <EditStage
+              {store}
+              {commands}
+              onRequestRefinement={requestRefinement}
+            />
+          {:else if workflow.activeStage === "complete"}
+            <CompleteStage
+              {store}
+              {commands}
+              onExtractIR={(sceneId) => extractSceneIR(sceneId)}
+            />
+          {:else if workflow.activeStage === "export"}
+            <ExportStage {store} />
+          {/if}
+        </div>
+      {/key}
+      {#snippet failed(err, reset)}
+        <div class="stage-crash">
+          <h3>Something went wrong</h3>
+          <p>{err instanceof Error ? err.message : "An unexpected error occurred."}</p>
+          <Button onclick={reset}>Try Again</Button>
+        </div>
+      {/snippet}
+    </svelte:boundary>
   </div>
 
   <GlossaryPanel />
@@ -436,6 +445,7 @@ function exportState() {
   .stage-content { display: flex; flex-direction: column; flex: 1; min-height: 0; }
   .error-margin { margin: 0 8px; }
   .loading-screen { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; min-height: 200px; }
+  .stage-crash { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 48px 24px; text-align: center; color: var(--text-secondary); }
   .new-project-form { display: flex; align-items: center; gap: 8px; }
   .project-title {
     font-size: 13px; font-weight: 600; color: var(--text-secondary); cursor: pointer;

--- a/src/app/components/stages/DraftStage.svelte
+++ b/src/app/components/stages/DraftStage.svelte
@@ -430,10 +430,10 @@ function handleUpdateChunk(index: number, changes: Partial<Chunk>) {
   }
 }
 
-function handleRemoveChunk(index: number) {
+async function handleRemoveChunk(index: number) {
   const sceneId = store.activeScenePlan?.id;
   if (!sceneId) return;
-  commands.removeChunk(sceneId, index);
+  await commands.removeChunk(sceneId, index);
 }
 
 async function handleDestroyChunk(index: number) {


### PR DESCRIPTION
## Summary

Batch of stability and config fixes from the pre-public audit:

- **Add `<svelte:boundary>` around stage workspace** — rendering crashes now show a fallback UI with a "Try Again" button instead of killing the entire app. Errors are logged and shown via the error banner. (closes #8)
- **Fix `apiDeleteWritingSample`** — now checks `response.ok` instead of silently swallowing server errors (closes #35)
- **Await `commands.removeChunk`** — chunk deletion errors are now surfaced to the user instead of being silently dropped (closes #35)
- **Move `svelte-codemirror-editor` to dependencies** — it's imported in production code (`AtlasJsonTab.svelte`), not just dev tooling (closes #37)
- **Fix `pnpm-workspace.yaml`** — use proper YAML list syntax instead of stringified JSON array (closes #38)

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 1425 tests pass (107 test files)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crash-isolation UI showing a “Something went wrong” message with a “Try Again” button to recover from runtime errors.

* **Bug Fixes**
  * Delete operations now validate HTTP responses and surface errors on failure.
  * Chunk removal now waits for completion before returning to avoid timing issues.

* **Chores**
  * Moved an editor package to runtime dependencies and corrected workspace configuration formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->