### PR TITLE
feat: abort/cancel for streaming generation + centralize model constants

### DIFF
--- a/server/profile/cipher.ts
+++ b/server/profile/cipher.ts
@@ -1,7 +1,7 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import type { PreferenceStatement } from "../../src/profile/types.js";
 import { truncateToTokens } from "../../src/tokens/index.js";
-import { generateId } from "../../src/types/index.js";
+import { DEFAULT_FAST_MODEL, generateId } from "../../src/types/index.js";
 import { textCall } from "./llm.js";
 
 export const CIPHER_BATCH_SIZE = 10;
@@ -43,7 +43,7 @@ Produce exactly 5 writing preferences. Each preference MUST:
 Format: numbered list. No headers, explanations, or examples.`;
 }
 
-const CIPHER_MODEL = "claude-haiku-4-5-20251001";
+const CIPHER_MODEL = DEFAULT_FAST_MODEL;
 
 export async function inferBatchPreferences(
   client: Anthropic,

--- a/server/profile/projectGuide.ts
+++ b/server/profile/projectGuide.ts
@@ -3,6 +3,7 @@ import { chunkDocument } from "../../src/profile/chunker.js";
 import type { PipelineConfig, VoiceGuide } from "../../src/profile/types.js";
 import { createDefaultPipelineConfig, createEmptyVoiceGuide, createWritingSample } from "../../src/profile/types.js";
 import { countTokens } from "../../src/tokens/index.js";
+import { DEFAULT_ANALYSIS_MODEL } from "../../src/types/metadata.js";
 import { textCall } from "./llm.js";
 import { analyzeChunks } from "./stage1.js";
 import { synthesizeDocument } from "./stage2.js";
@@ -196,7 +197,7 @@ The instruction should:
 
 Write ONLY the compact instruction. No preamble, no headers.`;
 
-  const injection = await textCall(client, "claude-sonnet-4-5-20250929", DISTILL_SYSTEM, prompt + sharedRules);
+  const injection = await textCall(client, DEFAULT_ANALYSIS_MODEL, DISTILL_SYSTEM, prompt + sharedRules);
 
   console.log(
     `[distillVoice] ring1Injection: ${countTokens(injection)} tokens from ${sections.length} source${sections.length !== 1 ? "s" : ""}`,

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import cors from "cors";
 import express from "express";
+import { DEFAULT_MODEL } from "../src/types/metadata.js";
 import { createApiRouter } from "./api/routes.js";
 import { getDatabase } from "./db/connection.js";
 import { errorHandler, requestLogger } from "./middleware.js";
@@ -59,7 +60,7 @@ app.post("/api/generate", async (req, res) => {
   try {
     const { systemMessage, userMessage, temperature, topP, maxTokens, model, outputSchema } = req.body;
 
-    const effectiveModel = model || "claude-sonnet-4-6";
+    const effectiveModel = model || DEFAULT_MODEL;
     const effectiveMaxTokens = maxTokens || 2000;
     console.log(`[generate] Starting: model=${effectiveModel}, max_tokens=${effectiveMaxTokens}`);
 
@@ -125,7 +126,7 @@ app.post("/api/generate/stream", async (req, res) => {
   }
 
   try {
-    const effectiveModel = model || "claude-sonnet-4-6";
+    const effectiveModel = model || DEFAULT_MODEL;
     const effectiveMaxTokens = maxTokens || 2000;
     console.log(`[stream] Starting generation: model=${effectiveModel}, max_tokens=${effectiveMaxTokens}`);
 

--- a/src/app/components/DraftingDesk.svelte
+++ b/src/app/components/DraftingDesk.svelte
@@ -19,6 +19,7 @@ let {
   reviewingChunks = new Set(),
   isAuditing = false,
   onGenerate,
+  onCancelGeneration,
   onUpdateChunk,
   onRemoveChunk,
   onDestroyChunk,
@@ -49,6 +50,7 @@ let {
   reviewingChunks?: Set<number>;
   isAuditing?: boolean;
   onGenerate: () => void;
+  onCancelGeneration: () => void;
   onUpdateChunk: (index: number, changes: Partial<Chunk>) => void;
   onRemoveChunk: (index: number) => void;
   onDestroyChunk?: (index: number) => void;
@@ -124,6 +126,10 @@ $effect(() => {
           <Button variant="danger" onclick={onCancelAutopilot}>
             Cancel Autopilot ({chunks.length}/{maxChunks})
           </Button>
+        {:else if isGenerating}
+          <Button variant="danger" onclick={onCancelGeneration}>
+            Cancel Generation
+          </Button>
         {:else}
           <Button
             variant="primary"
@@ -131,7 +137,7 @@ $effect(() => {
             disabled={!canGenerateNext}
             title={gateMessages.length > 0 ? gateMessages.join("\n") : undefined}
           >
-            {#if isGenerating}Generating...{:else if atChunkLimit}All chunks generated{:else}Generate Chunk {chunks.length + 1}{/if}
+            {#if atChunkLimit}All chunks generated{:else}Generate Chunk {chunks.length + 1}{/if}
           </Button>
           {#if canGenerateNext && chunks.length === 0}
             <Button onclick={onAutopilot} title="Generate all chunks, auto-accept, and complete scene">

--- a/src/app/components/stages/DraftStage.svelte
+++ b/src/app/components/stages/DraftStage.svelte
@@ -531,6 +531,7 @@ async function handleUpdateIR(ir: NarrativeIR) {
         {chunkAnnotations}
         {reviewingChunks}
         onGenerate={onGenerate}
+        onCancelGeneration={() => store.cancelGeneration()}
         onUpdateChunk={handleUpdateChunk}
         onRemoveChunk={handleRemoveChunk}
         onDestroyChunk={handleDestroyChunk}

--- a/src/app/components/stages/DraftStage.svelte
+++ b/src/app/components/stages/DraftStage.svelte
@@ -19,7 +19,7 @@ import {
   trimSuggestionOverlap,
 } from "../../../review/index.js";
 import type { Chunk, NarrativeIR, StyleDriftReport, VoiceSeparabilityReport } from "../../../types/index.js";
-import { getCanonicalText } from "../../../types/index.js";
+import { DEFAULT_MODEL, getCanonicalText } from "../../../types/index.js";
 import { Tabs } from "../../primitives/index.js";
 import type { Commands } from "../../store/commands.js";
 import type { ProjectStore } from "../../store/project.svelte.js";
@@ -51,7 +51,7 @@ let {
 } = $props();
 
 // ─── Editorial Review ───────────────────────────
-const REVIEW_MODEL = "claude-sonnet-4-6";
+const REVIEW_MODEL = DEFAULT_MODEL;
 const REVIEW_MAX_TOKENS = 2048;
 
 const llmReviewClient: LLMReviewClient = {

--- a/src/app/store/generation.svelte.ts
+++ b/src/app/store/generation.svelte.ts
@@ -49,7 +49,7 @@ export function createGenerationActions(store: ProjectStore, commands: Commands)
     await commands.saveAuditFlags(flags);
   }
 
-  /** Stream a chunk and return the result, or null if the stream failed or was cancelled. */
+  /** Stream a chunk and return the result, or null if the stream failed. Abort throws. */
   async function streamChunk(
     sceneId: string,
     chunkIndex: number,
@@ -118,17 +118,23 @@ export function createGenerationActions(store: ProjectStore, commands: Commands)
 
     try {
       const result = await streamChunk(sceneId, chunkIndex);
-      if (result) await persistChunkAndAudit(sceneId, chunkIndex, pendingChunk, result.text);
+      if (result) {
+        await persistChunkAndAudit(sceneId, chunkIndex, pendingChunk, result.text);
+      } else {
+        // Stream failed — remove the pending chunk
+        store.removeChunkForScene(sceneId, chunkIndex);
+      }
     } catch (err) {
-      handleGenerationError(err);
+      // Remove pending chunk on abort or unexpected error
+      store.removeChunkForScene(sceneId, chunkIndex);
+      if (!isAbortError(err)) store.setError(err instanceof Error ? err.message : "Generation failed");
     } finally {
       store.setGenerating(false);
     }
   }
 
-  function handleGenerationError(err: unknown) {
-    if (err instanceof DOMException && err.name === "AbortError") return;
-    store.setError(err instanceof Error ? err.message : "Generation failed");
+  function isAbortError(err: unknown): boolean {
+    return err instanceof DOMException && err.name === "AbortError";
   }
 
   async function runAuditManual(pinnedSceneId?: string) {

--- a/src/app/store/generation.svelte.ts
+++ b/src/app/store/generation.svelte.ts
@@ -13,7 +13,7 @@ import {
 } from "../../review/refine.js";
 import type { RefinementRequest, RefinementResult } from "../../review/refineTypes.js";
 import type { Chunk, NarrativeIR } from "../../types/index.js";
-import { generateId, getCanonicalText } from "../../types/index.js";
+import { DEFAULT_MODEL, generateId, getCanonicalText } from "../../types/index.js";
 import type { Commands } from "./commands.js";
 import type { ProjectStore } from "./project.svelte.js";
 
@@ -49,41 +49,17 @@ export function createGenerationActions(store: ProjectStore, commands: Commands)
     await commands.saveAuditFlags(flags);
   }
 
-  async function generateChunk(pinnedSceneId?: string) {
-    const plan = store.activeScenePlan;
-    if (!store.compiledPayload || !store.bible || !plan) {
-      store.setError("Cannot generate: missing compiled payload, bible, or scene plan");
-      return;
-    }
-
-    const sceneId = pinnedSceneId ?? plan.id;
-
-    store.setGenerating(true);
-    store.setError(null);
-
-    try {
-      const chunkId = generateId();
-      const chunkIndex = chunksForScene(sceneId).length;
-      const pendingChunk: Chunk = {
-        id: chunkId,
-        sceneId,
-        sequenceNumber: chunkIndex,
-        generatedText: "",
-        payloadHash: generateId(),
-        model: store.compiledPayload.model,
-        temperature: store.compiledPayload.temperature,
-        topP: store.compiledPayload.topP,
-        generatedAt: new Date().toISOString(),
-        status: "pending",
-        editedText: null,
-        humanNotes: null,
-      };
-      store.addChunk(pendingChunk);
-
-      let fullText = "";
-      let streamFailed = false;
-      let stopReason = "";
-      await generateStream(store.compiledPayload, {
+  /** Stream a chunk and return the result, or null if the stream failed or was cancelled. */
+  async function streamChunk(
+    sceneId: string,
+    chunkIndex: number,
+  ): Promise<{ text: string; stopReason: string } | null> {
+    let fullText = "";
+    let streamFailed = false;
+    let stopReason = "";
+    await generateStream(
+      store.compiledPayload!,
+      {
         onToken: (text) => {
           fullText += text;
           store.updateChunkForScene(sceneId, chunkIndex, { generatedText: fullText });
@@ -97,19 +73,62 @@ export function createGenerationActions(store: ProjectStore, commands: Commands)
           streamFailed = true;
           store.setError(`Generation failed: ${err}`);
         },
-      });
+      },
+      store.generationAbortController?.signal,
+    );
+    if (streamFailed) return null;
+    if (handleEmptyGeneration(fullText, stopReason, sceneId, chunkIndex)) return null;
+    return { text: fullText, stopReason };
+  }
 
-      // Abort if stream errored — don't persist partial/invalid prose
-      if (streamFailed) return;
+  function makePendingChunk(sceneId: string, chunkIndex: number): Chunk {
+    return {
+      id: generateId(),
+      sceneId,
+      sequenceNumber: chunkIndex,
+      generatedText: "",
+      payloadHash: generateId(),
+      model: store.compiledPayload!.model,
+      temperature: store.compiledPayload!.temperature,
+      topP: store.compiledPayload!.topP,
+      generatedAt: new Date().toISOString(),
+      status: "pending",
+      editedText: null,
+      humanNotes: null,
+    };
+  }
 
-      if (handleEmptyGeneration(fullText, stopReason, sceneId, chunkIndex)) return;
+  function canGenerate(): boolean {
+    return !!(store.compiledPayload && store.bible && store.activeScenePlan);
+  }
 
-      await persistChunkAndAudit(sceneId, chunkIndex, pendingChunk, fullText);
+  async function generateChunk(pinnedSceneId?: string) {
+    if (!canGenerate()) {
+      store.setError("Cannot generate: missing compiled payload, bible, or scene plan");
+      return;
+    }
+
+    const sceneId = pinnedSceneId ?? store.activeScenePlan!.id;
+    const chunkIndex = chunksForScene(sceneId).length;
+    const pendingChunk = makePendingChunk(sceneId, chunkIndex);
+
+    store.setGenerating(true);
+    store.setError(null);
+    store.addChunk(pendingChunk);
+
+    try {
+      const result = await streamChunk(sceneId, chunkIndex);
+      if (result) await persistChunkAndAudit(sceneId, chunkIndex, pendingChunk, result.text);
     } catch (err) {
-      store.setError(err instanceof Error ? err.message : "Generation failed");
+      handleGenerationError(err);
     } finally {
       store.setGenerating(false);
     }
+  }
+
+  function handleGenerationError(err: unknown) {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    store.setError(err instanceof Error ? err.message : "Generation failed");
   }
 
   async function runAuditManual(pinnedSceneId?: string) {
@@ -339,7 +358,7 @@ export function createGenerationActions(store: ProjectStore, commands: Commands)
       const { text: sceneText } = buildContinuousText(chunks);
       const userPrompt = buildRefinementUserPrompt(sceneText, request, scenePlan.title, scenePlan.narrativeGoal);
 
-      const raw = await callLLM(systemPrompt, userPrompt, "claude-sonnet-4-6", 4096, REFINEMENT_OUTPUT_SCHEMA);
+      const raw = await callLLM(systemPrompt, userPrompt, DEFAULT_MODEL, 4096, REFINEMENT_OUTPUT_SCHEMA);
       const { variants, parseError } = parseRefinementResponse(raw, store.bible.styleGuide.killList);
 
       if (variants.length === 0) {

--- a/src/app/store/project.svelte.ts
+++ b/src/app/store/project.svelte.ts
@@ -243,8 +243,8 @@ export class ProjectStore {
 
   cancelGeneration() {
     this.generationAbortController?.abort();
-    this.generationAbortController = null;
-    this.isGenerating = false;
+    // Don't set isGenerating = false here — let generateChunk's finally block
+    // handle it to avoid racing with a new generation starting immediately.
   }
 
   setAuditing(value: boolean) {
@@ -263,6 +263,8 @@ export class ProjectStore {
   cancelAutopilot() {
     this.autopilotCancelled = true;
     this.isAutopilot = false;
+    // Also abort the in-flight stream to stop token consumption immediately
+    this.generationAbortController?.abort();
   }
 
   setExtractingIR(sceneId: string | null) {

--- a/src/app/store/project.svelte.ts
+++ b/src/app/store/project.svelte.ts
@@ -54,6 +54,7 @@ export class ProjectStore {
   isGenerating = $state(false);
   isAutopilot = $state(false);
   autopilotCancelled = $state(false);
+  generationAbortController: AbortController | null = null;
   isAuditing = $state(false);
   reviewingChunks = $state<Set<number>>(new Set());
   extractingIRSceneId = $state<string | null>(null);
@@ -233,6 +234,17 @@ export class ProjectStore {
 
   setGenerating(value: boolean) {
     this.isGenerating = value;
+    if (value) {
+      this.generationAbortController = new AbortController();
+    } else {
+      this.generationAbortController = null;
+    }
+  }
+
+  cancelGeneration() {
+    this.generationAbortController?.abort();
+    this.generationAbortController = null;
+    this.isGenerating = false;
   }
 
   setAuditing(value: boolean) {

--- a/src/auditor/subtext.ts
+++ b/src/auditor/subtext.ts
@@ -1,5 +1,5 @@
 import type { AuditFlag, ScenePlan } from "../types/index.js";
-import { generateId } from "../types/index.js";
+import { DEFAULT_FAST_MODEL, generateId } from "../types/index.js";
 
 // ─── Subtext Compliance ──────────────────────────────────
 //
@@ -51,7 +51,7 @@ export async function checkSubtext(
   prose: string,
   plan: ScenePlan,
   client: SubtextClient,
-  model = "claude-haiku-4-5-20251001",
+  model = DEFAULT_FAST_MODEL,
 ): Promise<AuditFlag[]> {
   if (!plan.subtext) return [];
 

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -1,5 +1,5 @@
 import type { Bible, CompiledPayload } from "../types/index.js";
-import { generateId } from "../types/index.js";
+import { DEFAULT_MODEL, generateId } from "../types/index.js";
 
 export type { ParsedSceneBootstrap, SceneBootstrapParams } from "./sceneBootstrap.js";
 // Re-export scene bootstrap
@@ -120,7 +120,7 @@ Be specific but FUNCTIONAL. Every detail should anchor the reader in the space o
     temperature: 0.7,
     topP: 0.92,
     maxTokens: 16384,
-    model: "claude-sonnet-4-6",
+    model: DEFAULT_MODEL,
   };
 }
 

--- a/src/bootstrap/sceneBootstrap.ts
+++ b/src/bootstrap/sceneBootstrap.ts
@@ -1,5 +1,5 @@
 import type { CompiledPayload, ScenePlan } from "../types/index.js";
-import { createEmptyScenePlan, generateId } from "../types/index.js";
+import { createEmptyScenePlan, DEFAULT_MODEL, generateId } from "../types/index.js";
 import { extractJsonFromText } from "./index.js";
 
 // ─── Types ─────────────────────────────────────────────
@@ -547,7 +547,7 @@ CRITICAL: Maintain reader state continuity across scenes. Scene 2's readerStateE
     temperature: 0.7,
     topP: 0.92,
     maxTokens: params.sceneCount === 1 ? 8192 : 16384,
-    model: "claude-sonnet-4-6",
+    model: DEFAULT_MODEL,
   };
 }
 

--- a/src/ir/extractor.ts
+++ b/src/ir/extractor.ts
@@ -1,4 +1,5 @@
 import type { Bible, NarrativeIR, ScenePlan } from "../types/index.js";
+import { DEFAULT_MODEL } from "../types/index.js";
 import { parseIRResponse } from "./parser.js";
 
 // ─── LLM Client Interface ────────────────────────────────
@@ -83,7 +84,7 @@ export async function extractIR(
   plan: ScenePlan,
   bible: Bible,
   llmClient: IRLLMClient,
-  model = "claude-sonnet-4-6",
+  model = DEFAULT_MODEL,
 ): Promise<NarrativeIR> {
   const userMessage = buildIRExtractionPrompt(prose, plan, bible);
   const responseText = await llmClient.call(IR_SYSTEM_MESSAGE, userMessage, model, 4096);

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -96,7 +96,11 @@ function parseSSELine(line: string, callbacks: StreamCallbacks): void {
   }
 }
 
-export async function generateStream(payload: CompiledPayload, callbacks: StreamCallbacks): Promise<void> {
+export async function generateStream(
+  payload: CompiledPayload,
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal,
+): Promise<void> {
   const response = await fetch("/api/generate/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -108,6 +112,7 @@ export async function generateStream(payload: CompiledPayload, callbacks: Stream
       maxTokens: payload.maxTokens,
       model: payload.model,
     }),
+    signal,
   });
 
   if (!response.ok) {

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ANALYSIS_MODEL, DEFAULT_FAST_MODEL } from "../types/metadata.js";
 import { generateId } from "../types/utils.js";
 
 // ─── Input Types ───────────────────────────────────────
@@ -233,11 +234,11 @@ export function createWritingSample(filename: string | null, domain: string, tex
 
 export function createDefaultPipelineConfig(): PipelineConfig {
   return {
-    stage1ChunkModel: "claude-haiku-4-5-20251001",
-    stage2DocumentModel: "claude-haiku-4-5-20251001",
-    stage3ClusterModel: "claude-sonnet-4-5-20250929",
-    stage4FilterModel: "claude-sonnet-4-5-20250929",
-    stage5GuideModel: "claude-sonnet-4-5-20250929",
+    stage1ChunkModel: DEFAULT_FAST_MODEL,
+    stage2DocumentModel: DEFAULT_FAST_MODEL,
+    stage3ClusterModel: DEFAULT_ANALYSIS_MODEL,
+    stage4FilterModel: DEFAULT_ANALYSIS_MODEL,
+    stage5GuideModel: DEFAULT_ANALYSIS_MODEL,
     chunkTargetTokens: 10000,
     chunkOverlapTokens: 1000,
     minChunkTokens: 100,

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -104,6 +104,8 @@ export const MODEL_REGISTRY: Record<string, ModelSpec> = {
 };
 
 export const DEFAULT_MODEL = "claude-sonnet-4-6";
+export const DEFAULT_FAST_MODEL = "claude-haiku-4-5-20251001";
+export const DEFAULT_ANALYSIS_MODEL = "claude-sonnet-4-5-20250929";
 
 export function getModelSpec(modelId: string): ModelSpec {
   return (

--- a/tests/ui/DraftingDesk.test.ts
+++ b/tests/ui/DraftingDesk.test.ts
@@ -26,6 +26,7 @@ function defaultProps() {
     onCompleteScene: vi.fn(),
     onAutopilot: vi.fn(),
     onCancelAutopilot: vi.fn(),
+    onCancelGeneration: vi.fn(),
     onOpenIRInspector: vi.fn(),
     onExtractIR: vi.fn(),
     isAutopilot: false,
@@ -53,8 +54,8 @@ describe("DraftingDesk", () => {
     expect(screen.getByText("Run Audit")).toBeInTheDocument();
   });
 
-  it("shows 'Generating...' text when isGenerating", () => {
+  it("shows cancel button when isGenerating", () => {
     render(DraftingDesk, { ...defaultProps(), isGenerating: true });
-    expect(screen.getByText("Generating...")).toBeInTheDocument();
+    expect(screen.getByText("Cancel Generation")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Two LLM safety improvements to protect users from runaway API costs:

### Abort/cancel for streaming generation (closes #15)
- Add `AbortSignal` support to `generateStream()` in the LLM client
- Wire `AbortController` through `ProjectStore` — created on generation start, cleaned up on stop
- Add `store.cancelGeneration()` method that aborts the in-flight fetch, which triggers the server-side stream abort via `res.on("close")`
- Handle `AbortError` gracefully (user cancel is not shown as an error)
- Extract `streamChunk`, `makePendingChunk`, `canGenerate`, and `handleGenerationError` helpers (also satisfies Biome complexity limits)

### Centralize model names (closes #17)
- Add `DEFAULT_FAST_MODEL` (`claude-haiku-4-5-20251001`) and `DEFAULT_ANALYSIS_MODEL` (`claude-sonnet-4-5-20250929`) constants alongside existing `DEFAULT_MODEL` in `src/types/metadata.ts`
- Replace 12 hardcoded model string literals across 10 source files with the appropriate constant
- When models are retired, only one file needs updating instead of 10
- Fixtures, stories, and test files intentionally left as-is (they're snapshots of specific model outputs)

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 1425 tests pass (107 test files)
- [x] Pre-commit hooks pass (including Biome complexity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to cancel in-progress generation requests from the UI.

* **Refactor**
  * Centralized model selection across the app for consistent behavior.
  * Streaming generation now supports cancellation and more robust handling of failed/empty streams.

* **Tests**
  * Updated UI tests to expect a “Cancel Generation” control during active generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->