### PR TITLE
docs: update stale architecture docs and annotate plan documents

### DIFF
--- a/docs/architecture/02-context-compiler.md
+++ b/docs/architecture/02-context-compiler.md
@@ -11,12 +11,18 @@ The identity and rules layer. Built entirely from the Bible and compilation conf
 **Sections** (in priority order):
 | Section | Content | Immune |
 |---------|---------|--------|
-| `HEADER` | Model identity + preamble | Yes |
-| `BIBLE_VOICE` | Voice profile, sentence architecture, paragraph policy | No |
-| `BIBLE_CHARACTERS` | Character dossiers with voice notes | No |
-| `BIBLE_LOCATIONS` | Location palettes with sensory details | No |
-| `BIBLE_RULES` | Narrative rules (POV, subtext, exposition) | No |
-| `BIBLE_KILLLIST` | Avoid list (exact + structural bans) | No |
+| `HEADER` | Project voice preamble | Yes |
+| `METAPHORS` | Metaphoric register (approved/prohibited domains) | No |
+| `VOCABULARY` | Vocabulary preferences (preferred vs. avoided words) | No |
+| `SENTENCES` | Sentence architecture (variance, fragment policy) | No |
+| `PARAGRAPHS` | Paragraph policy (max sentences, single-sentence frequency) | No |
+| `NEVER_WRITE` | Kill list — exact word bans | Yes |
+| `STRUCTURAL_RULES` | Structural bans | Yes |
+| `NEGATIVE_EXEMPLARS` | Anti-voice examples ("do not sound like this") | No |
+| `POSITIVE_EXEMPLARS` | Voice examples ("the voice sounds like this") | No |
+| `POV` | POV rules (default, distance, interiority, reliability) | Yes |
+| `NARRATIVE_RULES` | Narrative rules (subtext, exposition, scene endings) | Yes |
+| `AUTHOR_VOICE` | Voice guide injection (when available) | No |
 
 `buildRing1(bible, config)` returns `{ sections: RingSection[], totalTokens }`.
 
@@ -27,10 +33,11 @@ The chapter-level continuity layer. Carries context between scenes.
 **Sections**:
 | Section | Content | Source |
 |---------|---------|--------|
-| `CHAPTER_ARC` | Working title, narrative function, pacing target | `ChapterArc` |
-| `PREVIOUS_SCENE_SUMMARY` | Events and deltas from completed scenes | Verified `NarrativeIR` |
-| `READER_STATE` | What the reader knows, suspects, is wrong about | `ChapterArc.readerStateEntering` |
-| `NARRATIVE_IR_CONTEXT` | Cross-scene facts and unresolved tensions | Accumulated IR |
+| `CHAPTER_BRIEF` | Working title, narrative function, register, pacing, ending posture | `ChapterArc` |
+| `READER_STATE_ENTRY` | What the reader knows, suspects, is wrong about, active tensions | `ChapterArc.readerStateEntering` |
+| `ACTIVE_SETUPS` | Planned/planted setups from the Bible | `Bible.narrativeRules.setups` |
+| `CHAR_STATE_{id}` | Per-character cumulative state from IR deltas (one section per character) | Verified `NarrativeIR` |
+| `UNRESOLVED_TENSIONS` | Unresolved tensions from last verified scene IR | Verified `NarrativeIR` |
 
 `buildRing2(chapterArc, completedScenes, sceneIRs, config)` returns `{ sections, totalTokens }`.
 
@@ -41,11 +48,18 @@ The scene-specific layer. Contains the immediate writing context.
 **Sections**:
 | Section | Content |
 |---------|---------|
-| `SCENE_PLAN` | Scene contract (goal, beats, POV, constraints) |
-| `ANTI_ABLATION` | Failure modes and anchor lines |
-| `PROSE_SO_FAR` | Canonical text from all prior chunks in this scene |
-| `CONTINUITY_BRIDGE` | Last chunk from previous scene (cross-scene continuity) |
+| `SCENE_CONTRACT` | Scene contract (goal, beats, POV, constraints) |
+| `VOICE_{name}` | Per-character voice fingerprints for speaking characters (immune) |
+| `POV_INTERIORITY` | POV character interiority guidance (immune for intimate/close) |
 | `SENSORY_PALETTE` | Location-specific sensory details (if location set) |
+| `SENSORY_GUARDRAIL` | Sensory invention guardrail (immune) |
+| `SCENE_CAST_GUARDRAIL` | Only listed characters may appear (immune) |
+| `SCENE_CAST` | Non-speaking present characters |
+| `ANCHOR_LINES` | Human-authored anchor lines with placement (immune) |
+| `CONTINUITY_BRIDGE` | Last chunk verbatim text (within-scene or cross-scene) |
+| `CONTINUITY_BRIDGE_STATE` | IR state bullets at scene entry (cross-scene only) |
+| `ANTI_ABLATION` | Failure modes and anchor lines (immune) |
+| `MICRO_DIRECTIVE` | Human notes from previous chunk (immune) |
 
 `buildRing3(scenePlan, chunks, previousSceneLastChunk, bible, config)` returns `{ sections, totalTokens }`.
 

--- a/docs/architecture/05-gates-workflow.md
+++ b/docs/architecture/05-gates-workflow.md
@@ -2,14 +2,14 @@
 
 Gates are pure validation functions that enforce workflow discipline. They answer the question: "Is this step ready to proceed?" Each gate returns `{ passed: boolean, messages: string[] }`.
 
-## Six Gates (`src/gates/index.ts`)
+## 13 Gates (`src/gates/index.ts`)
 
 ### 1. ScenePlan Gate — `checkScenePlanGate(plan)`
 **When**: Before generation can begin.
 **Checks**:
 - Scene plan has a title
 - Scene plan has a narrative goal
-- Scene plan has at least one chunk description
+- Scene plan has a failure mode to avoid
 - POV character is set
 
 ### 2. Compile Gate — `checkCompileGate(lintResult)`
@@ -20,8 +20,7 @@ Gates are pure validation functions that enforce workflow discipline. They answe
 ### 3. ChunkReview Gate — `checkChunkReviewGate(chunk)`
 **When**: Before accepting a chunk into the scene.
 **Checks**:
-- Chunk has a non-empty generated text
-- Chunk status is not "rejected"
+- Chunk status is "accepted" or "edited"
 
 ### 4. SceneCompletion Gate — `checkSceneCompletionGate(chunks, plan)`
 **When**: Before marking a scene as complete.
@@ -33,14 +32,12 @@ Gates are pure validation functions that enforce workflow discipline. They answe
 ### 5. AuditResolution Gate — `checkAuditResolutionGate(flags)`
 **When**: Before marking a scene as complete.
 **Checks**:
-- All critical audit flags are resolved
-- All warning flags are either resolved or dismissed
+- All critical audit flags are resolved (warnings are ignored)
 
 ### 6. BibleVersioning Gate — `checkBibleVersioningGate(bible, latestVersion)`
-**When**: Before saving a Bible update.
+**When**: Before generation, to ensure the compiled payload uses the current Bible.
 **Checks**:
-- Bible has at least one character
-- Bible has a non-empty voice profile section
+- Bible version is greater than or equal to the latest available version
 
 ## Scene Status Transitions
 
@@ -56,9 +53,45 @@ Gates are pure validation functions that enforce workflow discipline. They answe
 - **drafting → complete**: Manual — requires all gates to pass (SceneCompletion + AuditResolution)
 - Backward transitions are not permitted
 
-## Scene Workflow (`src/gates/scene-workflow.ts`)
+### 7. BootstrapToPlan Gate — `checkBootstrapToPlanGate(bible)`
+**When**: Before transitioning from bootstrap to planning stage.
+**Checks**:
+- Bible exists
+- Bible has at least 1 character
 
-The scene workflow module coordinates the full per-scene lifecycle:
+### 8. PlanToDraft Gate — `checkPlanToDraftGate(scenePlans)`
+**When**: Before transitioning from planning to drafting stage.
+**Checks**:
+- At least 1 scene plan with a title and narrative goal
+
+### 9. DraftToAudit Gate — `checkDraftToAuditGate(sceneChunks)`
+**When**: Before transitioning from drafting to audit stage.
+**Checks**:
+- At least 1 chunk generated in any scene
+
+### 10. AuditToEdit Gate — `checkAuditToEditGate(flags)`
+**When**: Before transitioning from audit to edit stage.
+**Checks**:
+- No unresolved critical audit flags
+
+### 11. EditToComplete Gate — `checkEditToCompleteGate()`
+**When**: Before transitioning from edit to complete stage.
+**Checks**:
+- Soft gate — always passes (editing is subjective)
+
+### 12. AuditToComplete Gate — `checkAuditToCompleteGate(flags)`
+**When**: Before transitioning from audit to complete stage.
+**Checks**:
+- No unresolved critical audit flags
+
+### 13. CompleteToExport Gate — `checkCompleteToExportGate(scenes)`
+**When**: Before transitioning from complete to export stage.
+**Checks**:
+- At least 1 scene marked "complete"
+
+## Scene Workflow
+
+The scene workflow coordinates the full per-scene lifecycle:
 
 1. **Plan** — Author defines the scene plan (ScenePlan gate must pass)
 2. **Compile** — System builds the prompt (Compile gate must pass)

--- a/docs/architecture/07-revision-learner.md
+++ b/docs/architecture/07-revision-learner.md
@@ -105,7 +105,7 @@ Analyzes edit *intensity* (not content) to propose parameter adjustments.
 
 | File | Purpose |
 |------|---------|
-| `src/learner/diff.ts` | Edit classification (39 tests) |
-| `src/learner/patterns.ts` | Wilson score accumulation (31 tests) |
-| `src/learner/proposals.ts` | Bible proposal generation (14 tests) |
+| `src/learner/diff.ts` | Edit classification (47 tests) |
+| `src/learner/patterns.ts` | Wilson score accumulation (86 tests) |
+| `src/learner/proposals.ts` | Bible proposal generation (19 tests) |
 | `src/learner/tuning.ts` | Parameter tuning proposals (20 tests) |

--- a/docs/architecture/10-persistence-layer.md
+++ b/docs/architecture/10-persistence-layer.md
@@ -53,7 +53,7 @@ Express server serving two roles:
 
 ### 2. REST API
 - Mounted at `/api/data` via `createApiRouter(db)`
-- Delegates to 11 repository modules
+- Delegates to 16 repository modules
 - `ensureProject()` auto-creates project rows on first Bible save
 
 ## Database
@@ -66,7 +66,7 @@ Express server serving two roles:
 
 ### Schema (`server/db/schema.ts`)
 
-12 tables with indexes:
+18 tables with indexes:
 
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
@@ -82,12 +82,18 @@ Express server serving two roles:
 | `edit_patterns` | Raw diff-classified edits | project_id, edit_type, sub_type |
 | `profile_adjustments` | Auto-tuning proposals | project_id, parameter, status |
 | `learned_patterns` | Accumulated edit patterns | project_id, pattern_type, status |
+| `voice_guide` | Singleton voice guide (version-controlled) | id, version, data (JSON) |
+| `voice_guide_versions` | Voice guide version history | version, data (JSON), change_reason |
+| `writing_samples` | Uploaded writing samples | filename, domain, word_count, data (JSON) |
+| `significant_edits` | Raw edit pairs awaiting batch CIPHER | project_id, chunk_id, processed |
+| `preference_statements` | CIPHER preference statements | project_id, statement, edit_count |
+| `project_voice_guide` | Per-project voice guide from edits + manuscript analysis | project_id, version, data (JSON) |
 
 Complex domain objects (Bible, ChapterArc, Chunk, NarrativeIR) are stored as JSON in `data` columns. Scalar fields (status, severity, resolved) are stored as native columns for indexing and querying.
 
 ### Repositories (`server/db/repositories/`)
 
-11 repository modules, one per resource:
+16 repository modules, one per resource:
 
 | Repository | Table |
 |------------|-------|
@@ -102,6 +108,11 @@ Complex domain objects (Bible, ChapterArc, Chunk, NarrativeIR) are stored as JSO
 | `edit-patterns.ts` | edit_patterns |
 | `learned-patterns.ts` | learned_patterns |
 | `profile-adjustments.ts` | profile_adjustments |
+| `voice-guide.ts` | voice_guide |
+| `writing-samples.ts` | writing_samples |
+| `significant-edits.ts` | significant_edits |
+| `preference-statements.ts` | preference_statements |
+| `project-voice-guide.ts` | project_voice_guide |
 
 Each repository exports CRUD functions that take a `Database` instance as the first argument. JSON columns are parsed on read and stringified on write.
 
@@ -111,7 +122,7 @@ Each repository exports CRUD functions that take a `Database` instance as the fi
 |------|---------|
 | `src/api/client.ts` | Typed browser REST client |
 | `server/proxy.ts` | Express server: LLM proxy + REST API |
-| `server/api/routes.ts` | REST router with 11 repository bindings |
+| `server/api/routes.ts` | REST router with 16 repository bindings |
 | `server/db/connection.ts` | SQLite singleton with WAL mode |
-| `server/db/schema.ts` | 12-table schema with indexes |
-| `server/db/repositories/` | 11 repository modules |
+| `server/db/schema.ts` | 18-table schema with indexes |
+| `server/db/repositories/` | 16 repository modules |

--- a/docs/architecture/11-ui-architecture.md
+++ b/docs/architecture/11-ui-architecture.md
@@ -69,7 +69,7 @@ Manages SSE streaming for chunk generation:
 
 ## Component Architecture
 
-### 23 Components (`src/app/components/`)
+### 40 Components (`src/app/components/`)
 
 | Component | Purpose |
 |-----------|---------|
@@ -92,14 +92,36 @@ Manages SSE streaming for chunk generation:
 | `BibleAuthoringModal.svelte` | Guided Bible editing with stepper |
 | `SceneAuthoringModal.svelte` | AI scene plan bootstrap |
 | `ExportModal.svelte` | Export with format selection |
+| `GlossaryPanel.svelte` | Glossary management |
+| `CharacterCard.svelte` | Character display card |
+| `CharacterFormFields.svelte` | Character editing form fields |
+| `LocationCard.svelte` | Location display card |
+| `LocationFormFields.svelte` | Location editing form fields |
+| `ProseEditor.svelte` | Rich prose editing |
+| `AnnotatedEditor.svelte` | Editor with inline annotations |
+| `AnnotationTooltip.svelte` | Tooltip for annotations |
+| `ReaderStateCard.svelte` | Reader epistemic state display |
+| `ReaderStateFields.svelte` | Reader state form fields |
+| `RefinementPopover.svelte` | Inline refinement popover |
+| `AtlasArcTab.svelte` | Atlas pane — chapter arc tab |
+| `AtlasBibleTab.svelte` | Atlas pane — Bible tab |
+| `AtlasJsonTab.svelte` | Atlas pane — JSON inspector tab |
+| `AtlasSceneTab.svelte` | Atlas pane — scene tab |
+| `BibleBootstrapTab.svelte` | Bible bootstrap tab |
+| `BibleGuidedFormTab.svelte` | Bible guided form tab |
+| `SceneBootstrapTab.svelte` | Scene bootstrap tab |
+| `SceneGuidedFormTab.svelte` | Scene guided form tab |
+| `StageCTA.svelte` | Stage call-to-action |
+| `VoiceProfilePanel.svelte` | Voice profile display and editing |
+| `WorkflowRail.svelte` | Workflow stage navigation rail |
 
-### 32 Primitives (`src/app/primitives/`)
+### 26 Primitives (`src/app/primitives/`)
 
 Reusable UI building blocks:
 
 - **Layout**: Pane, SectionPanel, CollapsibleSection, Modal, Tabs
-- **Input**: Button, Input, TextArea, Select, RadioGroup, TagInput, NumberRange, FormField
-- **Display**: Badge, MetricCard, Table, DiagnosticItem, ProgressBar, SegmentedBar, Spinner, CardList
+- **Input**: Button, Input, TextArea, Select, RadioGroup, TagInput, NumberRange, FormField, AdvancedToggle
+- **Display**: Badge, MetricCard, Table, DiagnosticItem, ProgressBar, SegmentedBar, Spinner, CardList, ErrorBanner, ExamplesDrawer, TruncatedProse
 - **Navigation**: Stepper
 
 ### Styling
@@ -129,6 +151,6 @@ initializeApp()
 | `src/app/store/generation.svelte.ts` | SSE streaming + autopilot |
 | `src/app/store/startup.ts` | `initializeApp`, `loadProject` |
 | `src/app/App.svelte` | Root component |
-| `src/app/components/` | 23 feature components |
-| `src/app/primitives/` | 32 reusable UI primitives |
+| `src/app/components/` | 40 feature components |
+| `src/app/primitives/` | 26 reusable UI primitives |
 | `src/app/styles/index.css` | Global CSS variables and shared classes |

--- a/docs/plans/2026-02-20-phase-2.5-and-3-design.md
+++ b/docs/plans/2026-02-20-phase-2.5-and-3-design.md
@@ -1,5 +1,7 @@
 # Phase 2.5 + Phase 3 Design
 
+> **Historical document.** This design plan was written during active development and references AI model consultations used during the design process. The implementation may have diverged — see `docs/architecture/` for current documentation.
+
 ## Status Quo
 
 Phase 2 built all the core logic modules but left them disconnected. The compiler, auditor, IR extractor, metrics, gates, and bootstrap all work in isolation (505 tests prove it). The backend has a full SQLite DB with 40+ REST endpoints. But the UI is client-side only — reload the page and everything is gone.

--- a/docs/plans/2026-02-25-context-expansion-impl.md
+++ b/docs/plans/2026-02-25-context-expansion-impl.md
@@ -1,5 +1,7 @@
 # Context Expansion Implementation Plan
 
+> **Historical document.** This implementation plan was written during active development and references AI model consultations used during the design review process.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Wire existing character/location data through the context compiler (Phase A) and add scene cast support (Phase B), closing 7 of 8 context gaps identified in the design doc.

--- a/docs/plans/2026-02-27-editorial-review-design.md
+++ b/docs/plans/2026-02-27-editorial-review-design.md
@@ -1,5 +1,7 @@
 # Editorial Review Engine — Design Document
 
+> **Historical document.** This design document was written during active development and references AI-assisted adversarial review sessions used during the design process.
+
 **Goal:** Provide real-time inline editorial feedback (squiggly underlines with hover tooltips) for prose chunks, using a two-tier system: instant deterministic checks plus on-save LLM-powered judgment-based review.
 
 **Architecture:** Three layers — Review Engine (types, LLM prompt, anchor resolution), Review Orchestrator (on-save pipeline, abort/retry, suppression), Annotated Editor (TipTap/ProseMirror + Svelte 5 decorations). Deterministic checks (kill list, rhythm, paragraph length) run instantly from existing auditor functions. LLM review adds tone, voice, grammar, POV, show-don't-tell, and other judgment-based categories.


### PR DESCRIPTION
## Summary

Fixes documentation drift found by the 18-reviewer pre-public audit.

### Architecture docs (closes #27)

- **02-context-compiler** — Replace stale Ring 1/2/3 section names with actual code identifiers (R1: 6→12 sections, R2: 4→5, R3: 5→12)
- **05-gates-workflow** — Fix gate count (6→13), correct 4 gate behavior descriptions, add 7 stage-transition gates, remove reference to non-existent file
- **07-revision-learner** — Update test counts (diff 39→47, patterns 31→86, proposals 14→19)
- **10-persistence-layer** — Update table count (12→18) and repo count (11→16), add missing entries
- **11-ui-architecture** — Update component count (23→40) and primitive count, add missing entries

### Plan documents (closes #28)

- Add "Historical document" notes to 3 plan files that reference AI model consultations (GPT-5, GPT-5-Codex, o3, PAL adversarial sessions), clarifying these are development-time design artifacts

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 1425 tests pass
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural documentation reflecting system organization changes: refined prompt structure with new language/voice decomposition, expanded workflow validation gates for scene processing, increased automated test coverage metrics, expanded database schema with new voice guide and writing sample tables, and updated UI component inventory.
  * Added historical context markers to planning documents for reference clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->