### PR TITLE
perf: parallelize startup + gate streaming derivations + add dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "src/**/*.ts": [
+    "src/**/*.{ts,svelte}": [
       "biome check --write"
     ],
     "server/**/*.ts": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "proxy": "tsx server/proxy.ts",
-    "dev:all": "concurrently \"vite\" \"tsx server/proxy.ts\"",
+    "dev:all": "concurrently \"vite --host ${HOST:-127.0.0.1}\" \"tsx server/proxy.ts\"",
     "eval": "tsx eval/runner.ts",
     "eval:quick": "tsx eval/runner.ts --rollouts=1",
     "eval:mock": "tsx eval/runner.ts --mock --rollouts=1",
@@ -66,6 +66,7 @@
     "@tiptap/pm": "^3.20.0",
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",
+    "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "svelte": "^5.53.0",
     "svelte-codemirror-editor": "^2.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       cors:
         specifier: ^2.8.6
         version: 2.8.6
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -68,7 +71,7 @@ importers:
         version: 2.4.2
       '@browserbasehq/stagehand':
         specifier: ^3.0.8
-        version: 3.0.8(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@16.6.1)(zod@3.25.76)
+        version: 3.0.8(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@17.4.2)(zod@3.25.76)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -1761,8 +1764,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -3668,7 +3671,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@3.0.8(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@16.6.1)(zod@3.25.76)':
+  '@browserbasehq/stagehand@3.0.8(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@17.4.2)(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@anthropic-ai/sdk': 0.39.0
@@ -3679,7 +3682,7 @@ snapshots:
       ai: 5.0.136(zod@3.25.76)
       deepmerge: 4.3.1
       devtools-protocol: 0.0.1464554
-      dotenv: 16.6.1
+      dotenv: 17.4.2
       fetch-cookie: 3.2.0
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0))(zod@3.25.76)
       pino: 9.14.0
@@ -5021,7 +5024,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dotenv@16.6.1: {}
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import Anthropic from "@anthropic-ai/sdk";
 import cors from "cors";
 import express from "express";

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -163,12 +163,16 @@ let editTitleValue = $state("");
 let boundaryErrorMsg = "";
 
 // ─── Prose word count ───────────────────────────
-let totalWordCount = $derived(
-  store.scenes.reduce((sum, scene) => {
+let cachedWordCount = 0;
+let totalWordCount = $derived.by(() => {
+  // Skip recomputation during streaming — word count updates when generation finishes
+  if (store.isGenerating) return cachedWordCount;
+  cachedWordCount = store.scenes.reduce((sum, scene) => {
     const chunks = store.sceneChunks[scene.plan.id] ?? [];
     return sum + chunks.reduce((s, c) => s + getCanonicalText(c).split(/\s+/).filter(Boolean).length, 0);
-  }, 0),
-);
+  }, 0);
+  return cachedWordCount;
+});
 
 // ─── State Export ────────────────────────────────
 function truncate(text: string, maxLen: number): string {

--- a/src/app/components/stages/DraftStage.svelte
+++ b/src/app/components/stages/DraftStage.svelte
@@ -355,13 +355,22 @@ let gateMessages = $derived.by(() => {
 let cachedStyleDrift: StyleDriftReport[] = [];
 let styleDriftReports = $derived.by((): StyleDriftReport[] => {
   if (store.isGenerating) return cachedStyleDrift;
-  if (!store.bible) { cachedStyleDrift = []; return []; }
+  if (!store.bible) {
+    cachedStyleDrift = [];
+    return [];
+  }
   const completedScenes = store.scenes.filter((s) => s.status === "complete");
-  if (completedScenes.length < 2) { cachedStyleDrift = []; return []; }
+  if (completedScenes.length < 2) {
+    cachedStyleDrift = [];
+    return [];
+  }
   const reports: StyleDriftReport[] = [];
   const baselineId = completedScenes[0]!.plan.id;
   const baselineChunks = store.sceneChunks[baselineId] ?? [];
-  if (baselineChunks.length === 0) { cachedStyleDrift = []; return []; }
+  if (baselineChunks.length === 0) {
+    cachedStyleDrift = [];
+    return [];
+  }
   const baselineProse = baselineChunks.map((c) => getCanonicalText(c)).join("\n\n");
   for (let i = 1; i < completedScenes.length; i++) {
     const scene = completedScenes[i]!;
@@ -380,14 +389,20 @@ let sceneTitles = $derived(Object.fromEntries(store.scenes.map((s) => [s.plan.id
 let cachedVoiceReport: VoiceSeparabilityReport | null = null;
 let voiceReport = $derived.by((): VoiceSeparabilityReport | null => {
   if (store.isGenerating) return cachedVoiceReport;
-  if (!store.bible || store.bible.characters.length < 2) { cachedVoiceReport = null; return null; }
+  if (!store.bible || store.bible.characters.length < 2) {
+    cachedVoiceReport = null;
+    return null;
+  }
   const sceneTexts = store.scenes
     .map((s) => ({
       sceneId: s.plan.id,
       prose: (store.sceneChunks[s.plan.id] ?? []).map((c) => getCanonicalText(c)).join("\n\n"),
     }))
     .filter((s) => s.prose.length > 0);
-  if (sceneTexts.length === 0) { cachedVoiceReport = null; return null; }
+  if (sceneTexts.length === 0) {
+    cachedVoiceReport = null;
+    return null;
+  }
   cachedVoiceReport = measureVoiceSeparability(sceneTexts, store.bible);
   return cachedVoiceReport;
 });

--- a/src/app/components/stages/DraftStage.svelte
+++ b/src/app/components/stages/DraftStage.svelte
@@ -351,7 +351,10 @@ let gateMessages = $derived.by(() => {
   return msgs;
 });
 
+// Skip expensive NLP computations during streaming to avoid recomputing on every token
+let cachedStyleDrift: StyleDriftReport[] = [];
 let styleDriftReports = $derived.by((): StyleDriftReport[] => {
+  if (store.isGenerating) return cachedStyleDrift;
   if (!store.bible) return [];
   const completedScenes = store.scenes.filter((s) => s.status === "complete");
   if (completedScenes.length < 2) return [];
@@ -367,13 +370,16 @@ let styleDriftReports = $derived.by((): StyleDriftReport[] => {
     const prose = chunks.map((c) => getCanonicalText(c)).join("\n\n");
     reports.push(computeStyleDriftFromProse(baselineId, baselineProse, scene.plan.id, prose));
   }
+  cachedStyleDrift = reports;
   return reports;
 });
 
 let baselineSceneTitle = $derived(store.scenes.find((s) => s.status === "complete")?.plan.title ?? "Scene 1");
 let sceneTitles = $derived(Object.fromEntries(store.scenes.map((s) => [s.plan.id, s.plan.title])));
 
+let cachedVoiceReport: VoiceSeparabilityReport | null = null;
 let voiceReport = $derived.by((): VoiceSeparabilityReport | null => {
+  if (store.isGenerating) return cachedVoiceReport;
   if (!store.bible || store.bible.characters.length < 2) return null;
   const sceneTexts = store.scenes
     .map((s) => ({
@@ -382,7 +388,8 @@ let voiceReport = $derived.by((): VoiceSeparabilityReport | null => {
     }))
     .filter((s) => s.prose.length > 0);
   if (sceneTexts.length === 0) return null;
-  return measureVoiceSeparability(sceneTexts, store.bible);
+  cachedVoiceReport = measureVoiceSeparability(sceneTexts, store.bible);
+  return cachedVoiceReport;
 });
 
 // ─── Handlers ───────────────────────────────────

--- a/src/app/components/stages/DraftStage.svelte
+++ b/src/app/components/stages/DraftStage.svelte
@@ -355,13 +355,13 @@ let gateMessages = $derived.by(() => {
 let cachedStyleDrift: StyleDriftReport[] = [];
 let styleDriftReports = $derived.by((): StyleDriftReport[] => {
   if (store.isGenerating) return cachedStyleDrift;
-  if (!store.bible) return [];
+  if (!store.bible) { cachedStyleDrift = []; return []; }
   const completedScenes = store.scenes.filter((s) => s.status === "complete");
-  if (completedScenes.length < 2) return [];
+  if (completedScenes.length < 2) { cachedStyleDrift = []; return []; }
   const reports: StyleDriftReport[] = [];
   const baselineId = completedScenes[0]!.plan.id;
   const baselineChunks = store.sceneChunks[baselineId] ?? [];
-  if (baselineChunks.length === 0) return [];
+  if (baselineChunks.length === 0) { cachedStyleDrift = []; return []; }
   const baselineProse = baselineChunks.map((c) => getCanonicalText(c)).join("\n\n");
   for (let i = 1; i < completedScenes.length; i++) {
     const scene = completedScenes[i]!;
@@ -380,14 +380,14 @@ let sceneTitles = $derived(Object.fromEntries(store.scenes.map((s) => [s.plan.id
 let cachedVoiceReport: VoiceSeparabilityReport | null = null;
 let voiceReport = $derived.by((): VoiceSeparabilityReport | null => {
   if (store.isGenerating) return cachedVoiceReport;
-  if (!store.bible || store.bible.characters.length < 2) return null;
+  if (!store.bible || store.bible.characters.length < 2) { cachedVoiceReport = null; return null; }
   const sceneTexts = store.scenes
     .map((s) => ({
       sceneId: s.plan.id,
       prose: (store.sceneChunks[s.plan.id] ?? []).map((c) => getCanonicalText(c)).join("\n\n"),
     }))
     .filter((s) => s.prose.length > 0);
-  if (sceneTexts.length === 0) return null;
+  if (sceneTexts.length === 0) { cachedVoiceReport = null; return null; }
   cachedVoiceReport = measureVoiceSeparability(sceneTexts, store.bible);
   return cachedVoiceReport;
 });

--- a/src/app/store/startup.ts
+++ b/src/app/store/startup.ts
@@ -45,10 +45,16 @@ export async function loadProject(store: ProjectStore, projectId: string): Promi
       }));
     }
 
-    // Fetch chunks for each scene
+    // Fetch chunks for all scenes in parallel
     const sceneChunks: Record<string, Chunk[]> = {};
-    for (const scene of scenes) {
-      sceneChunks[scene.plan.id] = await api.apiListChunks(scene.plan.id);
+    const chunkResults = await Promise.all(
+      scenes.map(async (scene) => ({
+        sceneId: scene.plan.id,
+        chunks: await api.apiListChunks(scene.plan.id),
+      })),
+    );
+    for (const { sceneId, chunks } of chunkResults) {
+      sceneChunks[sceneId] = chunks;
     }
 
     // Fetch narrative IRs for all scenes in the chapter


### PR DESCRIPTION
## Summary

Three fixes bundled: startup performance, streaming performance, and DX improvement.

### Parallel chunk loading at startup (closes #22)
Replace sequential `await` loop with `Promise.all` for scene chunk fetching. A novel with 20 scenes now fires 20 parallel requests instead of 20 sequential round-trips.

### Gate expensive derived values during streaming (closes #23)
`styleDriftReports`, `voiceReport`, and `totalWordCount` were recomputing on every streaming token (dozens of times/second) even though their inputs don't change during generation. Now they return cached values while `store.isGenerating` is true and recompute when generation finishes.

### Add dotenv for .env loading
- Add `dotenv/config` import so the server automatically loads `.env` on startup (previously required passing env vars inline)
- Update `dev:all` to pass `HOST` to Vite's `--host` flag so both servers respect the same bind address

## Test plan

- [x] `pnpm typecheck` passes
- [x] All 1425 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster startup via concurrent scene data loading.
  * Reduced UI stalls during content generation by caching counts and analyses while streaming.
* **Bug Fixes / Reliability**
  * Prevents flicker or incorrect interim style and voice reports during generation.
* **New Features**
  * Environment-variable driven host configuration and runtime env loading for flexible deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->