### PR TITLE
fix: gate Edit stage refinement popover on mouseup, not mid-drag

### DIFF
--- a/src/app/components/ProseEditor.svelte
+++ b/src/app/components/ProseEditor.svelte
@@ -84,7 +84,10 @@ $effect(() => {
       }
 
       const text = updatedEd.state.doc.textBetween(from, to, "\n\n");
-      if (!text.trim()) return;
+      if (!text.trim()) {
+        if (mouseDown) pendingSelection = null;
+        return;
+      }
 
       // Position popover below selection end
       const coords = updatedEd.view.coordsAtPos(to);
@@ -219,9 +222,16 @@ function handleCancel() {
 function handleEditorMousedown() {
   mouseDown = true;
   pendingSelection = null;
+  // Dismiss any existing popover so it doesn't block the new selection
+  if (refinementState === "selecting" || refinementState === "reviewing" || refinementState === "cutting") {
+    refinementState = "idle";
+    variants = [];
+    cutPreviewText = null;
+  }
 }
 
 function handleEditorMouseup() {
+  if (!mouseDown && !pendingSelection) return;
   mouseDown = false;
   if (pendingSelection) {
     selectedText = pendingSelection.text;
@@ -234,11 +244,19 @@ function handleEditorMouseup() {
     cutPreviewText = null;
   }
 }
+
+// Listen on window so drags released outside the editor still resolve
+$effect(() => {
+  window.addEventListener("mouseup", handleEditorMouseup);
+  return () => {
+    window.removeEventListener("mouseup", handleEditorMouseup);
+  };
+});
 </script>
 
 <div class="prose-editor-wrapper">
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div bind:this={editorElement} class="prose-editor" onmousedown={handleEditorMousedown} onmouseup={handleEditorMouseup}></div>
+  <div bind:this={editorElement} class="prose-editor" onmousedowncapture={handleEditorMousedown}></div>
 
   {#if refinementState === "cutting" && cutPreviewText !== null}
     <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/app/components/ProseEditor.svelte
+++ b/src/app/components/ProseEditor.svelte
@@ -33,6 +33,15 @@ let {
 let editorElement: HTMLDivElement;
 let editor: Editor | null = null;
 let applyingExternal = false;
+let mouseDown = false;
+let pendingSelection: {
+  text: string;
+  from: number;
+  to: number;
+  start: number;
+  end: number;
+  position: { top: number; left: number; anchorBottom?: number };
+} | null = null;
 
 // State machine
 let refinementState = $state<RefinementState>("idle");
@@ -66,7 +75,8 @@ $effect(() => {
       if (applyingExternal) return;
       const { from, to } = updatedEd.state.selection;
       if (from === to) {
-        // Collapsed selection — dismiss popover
+        // Collapsed selection — dismiss popover and clear pending
+        pendingSelection = null;
         if (refinementState === "selecting") {
           refinementState = "idle";
         }
@@ -76,22 +86,35 @@ $effect(() => {
       const text = updatedEd.state.doc.textBetween(from, to, "\n\n");
       if (!text.trim()) return;
 
-      selectedText = text;
-      selectionStart = posToOffset(updatedEd, from);
-      selectionEnd = posToOffset(updatedEd, to);
-
-      // Position popover below selection
+      // Position popover below selection end
       const coords = updatedEd.view.coordsAtPos(to);
       const wrapperRect = editorElement.getBoundingClientRect();
-      popoverPosition = {
+      const position = {
         top: coords.bottom - wrapperRect.top + 6,
         left: Math.max(0, coords.left - wrapperRect.left),
         anchorBottom: coords.top - wrapperRect.top,
       };
 
-      refinementState = "selecting";
-      variants = [];
-      cutPreviewText = null;
+      if (mouseDown) {
+        // User is mid-drag — stash but don't show popover yet
+        pendingSelection = {
+          text,
+          from,
+          to,
+          start: posToOffset(updatedEd, from),
+          end: posToOffset(updatedEd, to),
+          position,
+        };
+      } else {
+        // Keyboard selection (Shift+Arrow) — show immediately
+        selectedText = text;
+        selectionStart = posToOffset(updatedEd, from);
+        selectionEnd = posToOffset(updatedEd, to);
+        popoverPosition = position;
+        refinementState = "selecting";
+        variants = [];
+        cutPreviewText = null;
+      }
     },
   });
 
@@ -192,10 +215,30 @@ function handleCancel() {
   variants = [];
   cutPreviewText = null;
 }
+
+function handleEditorMousedown() {
+  mouseDown = true;
+  pendingSelection = null;
+}
+
+function handleEditorMouseup() {
+  mouseDown = false;
+  if (pendingSelection) {
+    selectedText = pendingSelection.text;
+    selectionStart = pendingSelection.start;
+    selectionEnd = pendingSelection.end;
+    popoverPosition = pendingSelection.position;
+    pendingSelection = null;
+    refinementState = "selecting";
+    variants = [];
+    cutPreviewText = null;
+  }
+}
 </script>
 
 <div class="prose-editor-wrapper">
-  <div bind:this={editorElement} class="prose-editor"></div>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div bind:this={editorElement} class="prose-editor" onmousedown={handleEditorMousedown} onmouseup={handleEditorMouseup}></div>
 
   {#if refinementState === "cutting" && cutPreviewText !== null}
     <!-- svelte-ignore a11y_no_static_element_interactions -->


### PR DESCRIPTION
## Summary

- Closes #62 — Edit stage text selection immediately triggered the revision panel with a single character, making the editorial workflow unusable

## Root cause

TipTap's `onSelectionUpdate` fires on every selection transaction including the initial mousedown. The handler was immediately setting `refinementState = "selecting"`, which rendered the `RefinementPopover` before the user could drag to complete their selection.

## Fix

Track `mouseDown` state on the editor wrapper. During a drag, `onSelectionUpdate` stashes selection data in `pendingSelection` without showing the popover. On `mouseup`, the stashed selection is promoted and the popover appears with the final selection. Keyboard selections (Shift+Arrow) still show the popover immediately since no mousedown is involved.

Single-file change: `src/app/components/ProseEditor.svelte`

## Test plan

- [x] `pnpm check-all` — 1429 tests pass
- [ ] Click and drag to select text in Edit stage — popover should appear only after mouseup
- [ ] Single click (no drag) should not show popover (collapsed selection)
- [ ] Shift+Arrow keyboard selection should still show popover immediately
- [ ] Double-click to select word should show popover (mouseup fires after double-click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection responsiveness and stability in the editor for mouse and keyboard interactions.

* **New Features**
  * Selection made while dragging is buffered and only commits on mouseup (including outside the editor).
  * Starting a drag resets selection-related UI; empty selections are cleared automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->