### PR TITLE
feat(logger): F1 logger infrastructure (#19)

### DIFF
--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -26,12 +26,21 @@ function isProduction(): boolean {
   return process.env.NODE_ENV === "production";
 }
 
-function errorFields(err: Error): Record<string, unknown> {
+function errorContext(err: Error): Record<string, unknown> {
   return {
-    error_name: err.name,
-    error_message: err.message,
-    error_stack: err.stack,
+    error: { name: err.name, message: err.message, stack: err.stack },
   };
+}
+
+// JSON.stringify can throw on circular refs or BigInt. Logging must never be
+// a failure path for callers, so fall back to a marker payload on any error.
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "unknown serialization error";
+    return JSON.stringify({ serialization_error: reason });
+  }
 }
 
 function formatPretty(
@@ -42,7 +51,7 @@ function formatPretty(
 ): string {
   const base = `[${tag}] ${level.toUpperCase()} ${message}`;
   if (!context || Object.keys(context).length === 0) return `${base}\n`;
-  return `${base} ${JSON.stringify(context)}\n`;
+  return `${base} ${safeStringify(context)}\n`;
 }
 
 function formatJson(
@@ -58,7 +67,7 @@ function formatJson(
     tag,
     message,
   };
-  return `${JSON.stringify(payload)}\n`;
+  return `${safeStringify(payload)}\n`;
 }
 
 function emit(
@@ -69,7 +78,7 @@ function emit(
 ): void {
   if (LEVEL_ORDER[level] < LEVEL_ORDER[resolveThreshold()]) return;
 
-  const ctx: Record<string, unknown> | undefined = context instanceof Error ? errorFields(context) : context;
+  const ctx: Record<string, unknown> | undefined = context instanceof Error ? errorContext(context) : context;
 
   const line = isProduction() ? formatJson(level, tag, message, ctx) : formatPretty(level, tag, message, ctx);
 

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -52,11 +52,11 @@ function formatJson(
   context: Record<string, unknown> | undefined,
 ): string {
   const payload = {
+    ...(context ?? {}),
     timestamp: new Date().toISOString(),
     level,
     tag,
     message,
-    ...(context ?? {}),
   };
   return `${JSON.stringify(payload)}\n`;
 }

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -1,0 +1,87 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown> | Error): void;
+}
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function resolveThreshold(): LogLevel {
+  const raw = process.env.LOG_LEVEL;
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error") {
+    return raw;
+  }
+  return "info";
+}
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function errorFields(err: Error): Record<string, unknown> {
+  return {
+    error_name: err.name,
+    error_message: err.message,
+    error_stack: err.stack,
+  };
+}
+
+function formatPretty(
+  level: LogLevel,
+  tag: string,
+  message: string,
+  context: Record<string, unknown> | undefined,
+): string {
+  const base = `[${tag}] ${level.toUpperCase()} ${message}`;
+  if (!context || Object.keys(context).length === 0) return `${base}\n`;
+  return `${base} ${JSON.stringify(context)}\n`;
+}
+
+function formatJson(
+  level: LogLevel,
+  tag: string,
+  message: string,
+  context: Record<string, unknown> | undefined,
+): string {
+  const payload = {
+    timestamp: new Date().toISOString(),
+    level,
+    tag,
+    message,
+    ...(context ?? {}),
+  };
+  return `${JSON.stringify(payload)}\n`;
+}
+
+function emit(
+  level: LogLevel,
+  tag: string,
+  message: string,
+  context: Record<string, unknown> | Error | undefined,
+): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[resolveThreshold()]) return;
+
+  const ctx: Record<string, unknown> | undefined = context instanceof Error ? errorFields(context) : context;
+
+  const line = isProduction() ? formatJson(level, tag, message, ctx) : formatPretty(level, tag, message, ctx);
+
+  const stream = level === "warn" || level === "error" ? process.stderr : process.stdout;
+  stream.write(line);
+}
+
+export function createLogger(tag: string): Logger {
+  return {
+    debug: (message, context) => emit("debug", tag, message, context),
+    info: (message, context) => emit("info", tag, message, context),
+    warn: (message, context) => emit("warn", tag, message, context),
+    error: (message, context) => emit("error", tag, message, context),
+  };
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,55 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown> | Error): void;
+}
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function resolveThreshold(): LogLevel {
+  const raw = (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL;
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error") {
+    return raw;
+  }
+  return "info";
+}
+
+function serializeError(err: Error): Record<string, unknown> {
+  return { name: err.name, message: err.message, stack: err.stack };
+}
+
+function emit(
+  level: LogLevel,
+  tag: string,
+  message: string,
+  context: Record<string, unknown> | Error | undefined,
+): void {
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[resolveThreshold()]) return;
+
+  const line = `[${tag}] ${message}`;
+  const payload = context instanceof Error ? serializeError(context) : context;
+
+  const sink = console[level].bind(console);
+  if (payload === undefined) {
+    sink(line);
+  } else {
+    sink(line, payload);
+  }
+}
+
+export function createLogger(tag: string): Logger {
+  return {
+    debug: (message, context) => emit("debug", tag, message, context),
+    info: (message, context) => emit("info", tag, message, context),
+    warn: (message, context) => emit("warn", tag, message, context),
+    error: (message, context) => emit("error", tag, message, context),
+  };
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -23,16 +23,17 @@ function resolveThreshold(): LogLevel {
 }
 
 function serializeError(err: Error): Record<string, unknown> {
-  return { name: err.name, message: err.message, stack: err.stack };
+  return { error: { name: err.name, message: err.message, stack: err.stack } };
 }
 
 function emit(
   level: LogLevel,
+  threshold: LogLevel,
   tag: string,
   message: string,
   context: Record<string, unknown> | Error | undefined,
 ): void {
-  if (LEVEL_ORDER[level] < LEVEL_ORDER[resolveThreshold()]) return;
+  if (LEVEL_ORDER[level] < LEVEL_ORDER[threshold]) return;
 
   const line = `[${tag}] ${message}`;
   const payload = context instanceof Error ? serializeError(context) : context;
@@ -46,10 +47,13 @@ function emit(
 }
 
 export function createLogger(tag: string): Logger {
+  // VITE_LOG_LEVEL is baked in at build time, so resolving once per logger
+  // instance is correct and avoids a per-emit env lookup in hot paths.
+  const threshold = resolveThreshold();
   return {
-    debug: (message, context) => emit("debug", tag, message, context),
-    info: (message, context) => emit("info", tag, message, context),
-    warn: (message, context) => emit("warn", tag, message, context),
-    error: (message, context) => emit("error", tag, message, context),
+    debug: (message, context) => emit("debug", threshold, tag, message, context),
+    info: (message, context) => emit("info", threshold, tag, message, context),
+    warn: (message, context) => emit("warn", threshold, tag, message, context),
+    error: (message, context) => emit("error", threshold, tag, message, context),
   };
 }

--- a/tests/lib/logger.test.ts
+++ b/tests/lib/logger.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLogger, type LogLevel } from "@/lib/logger";
+
+// The client logger reads import.meta.env.VITE_LOG_LEVEL.
+// Vitest exposes import.meta.env as a mutable object, so each test
+// sets the level it wants and restores afterwards.
+const originalLevel = import.meta.env.VITE_LOG_LEVEL as LogLevel | undefined;
+
+describe("createLogger (client)", () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = originalLevel;
+  });
+
+  it("prefixes every message with the tag in square brackets", () => {
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = "debug";
+    const log = createLogger("compiler");
+    log.info("hello");
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0]?.[0]).toContain("[compiler]");
+    expect(infoSpy.mock.calls[0]?.[0]).toContain("hello");
+  });
+
+  it("filters messages below the configured level", () => {
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = "warn";
+    const log = createLogger("x");
+    log.debug("d");
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to info when VITE_LOG_LEVEL is unset", () => {
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = undefined;
+    const log = createLogger("x");
+    log.debug("d");
+    log.info("i");
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes context as a second argument to console.*", () => {
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = "debug";
+    const log = createLogger("x");
+    log.info("msg", { userId: 42 });
+    expect(infoSpy.mock.calls[0]?.[1]).toEqual({ userId: 42 });
+  });
+
+  it("serializes an Error passed to .error into name/message/stack", () => {
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = "debug";
+    const log = createLogger("x");
+    const err = new Error("boom");
+    log.error("failed", err);
+    const ctx = errorSpy.mock.calls[0]?.[1] as { name: string; message: string; stack?: string };
+    expect(ctx.name).toBe("Error");
+    expect(ctx.message).toBe("boom");
+    expect(typeof ctx.stack).toBe("string");
+  });
+
+  it("omits the context argument entirely when none is provided", () => {
+    (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = "debug";
+    const log = createLogger("x");
+    log.info("bare");
+    expect(infoSpy.mock.calls[0]?.length).toBe(1);
+  });
+});

--- a/tests/lib/logger.test.ts
+++ b/tests/lib/logger.test.ts
@@ -62,15 +62,15 @@ describe("createLogger (client)", () => {
     expect(infoSpy.mock.calls[0]?.[1]).toEqual({ userId: 42 });
   });
 
-  it("serializes an Error passed to .error into name/message/stack", () => {
+  it("serializes an Error passed to .error as a nested error object", () => {
     (import.meta.env as Record<string, unknown>).VITE_LOG_LEVEL = "debug";
     const log = createLogger("x");
     const err = new Error("boom");
     log.error("failed", err);
-    const ctx = errorSpy.mock.calls[0]?.[1] as { name: string; message: string; stack?: string };
-    expect(ctx.name).toBe("Error");
-    expect(ctx.message).toBe("boom");
-    expect(typeof ctx.stack).toBe("string");
+    const ctx = errorSpy.mock.calls[0]?.[1] as { error: { name: string; message: string; stack?: string } };
+    expect(ctx.error.name).toBe("Error");
+    expect(ctx.error.message).toBe("boom");
+    expect(typeof ctx.error.stack).toBe("string");
   });
 
   it("omits the context argument entirely when none is provided", () => {

--- a/tests/server/lib/logger.test.ts
+++ b/tests/server/lib/logger.test.ts
@@ -63,6 +63,8 @@ describe("createLogger (server)", () => {
     log.info("hello", { rows: 3 });
     const raw = stdoutSpy.mock.calls[0]?.[0] as string;
     expect(raw.endsWith("\n")).toBe(true);
+    // Single-line contract: no embedded newlines before the terminating one.
+    expect(raw.slice(0, -1)).not.toContain("\n");
     const line = raw.trim();
     expect(line).toContain("[db]");
     expect(line).toContain("hello");
@@ -102,15 +104,37 @@ describe("createLogger (server)", () => {
     expect(typeof parsed.timestamp).toBe("string");
   });
 
-  it("serializes an Error passed to .error into name/message/stack", () => {
+  it("serializes an Error passed to .error as a nested error object", () => {
     setEnv("debug", "production");
     const log = createLogger("db");
     log.error("failed", new Error("boom"));
     const raw = stderrSpy.mock.calls[0]?.[0] as string;
     const parsed = JSON.parse(raw.trim());
     expect(parsed.message).toBe("failed");
-    expect(parsed.error_name).toBe("Error");
-    expect(parsed.error_message).toBe("boom");
-    expect(typeof parsed.error_stack).toBe("string");
+    expect(parsed.error.name).toBe("Error");
+    expect(parsed.error.message).toBe("boom");
+    expect(typeof parsed.error.stack).toBe("string");
+  });
+
+  it("does not throw when context contains circular references", () => {
+    setEnv("debug", "production");
+    const log = createLogger("db");
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    expect(() => log.info("cycle", circular)).not.toThrow();
+    const raw = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.serialization_error).toBeDefined();
+    expect(typeof parsed.serialization_error).toBe("string");
+  });
+
+  it("does not throw when context contains a BigInt", () => {
+    setEnv("debug", "development");
+    const log = createLogger("db");
+    expect(() => log.info("bignum", { n: 10n })).not.toThrow();
+    const raw = stdoutSpy.mock.calls[0]?.[0] as string;
+    // Falls back to the serialization_error marker; must still write a single newline-terminated line.
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(raw).toContain("serialization_error");
   });
 });

--- a/tests/server/lib/logger.test.ts
+++ b/tests/server/lib/logger.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLogger, type LogLevel } from "../../../server/lib/logger";
+
+const originalLevel = process.env.LOG_LEVEL;
+const originalNodeEnv = process.env.NODE_ENV;
+
+function setEnv(level: LogLevel | undefined, nodeEnv: string | undefined) {
+  if (level === undefined) delete process.env.LOG_LEVEL;
+  else process.env.LOG_LEVEL = level;
+  if (nodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = nodeEnv;
+}
+
+describe("createLogger (server)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: spyOn on overloaded process.stdout.write signature
+  let stdoutSpy: any;
+  // biome-ignore lint/suspicious/noExplicitAny: spyOn on overloaded process.stderr.write signature
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setEnv(originalLevel as LogLevel | undefined, originalNodeEnv);
+  });
+
+  it("writes info/debug to stdout and warn/error to stderr", () => {
+    setEnv("debug", "development");
+    const log = createLogger("db");
+    log.debug("d");
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+    expect(stdoutSpy).toHaveBeenCalledTimes(2);
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("filters messages below the configured level", () => {
+    setEnv("warn", "development");
+    const log = createLogger("db");
+    log.debug("d");
+    log.info("i");
+    log.warn("w");
+    log.error("e");
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("defaults to info when LOG_LEVEL is unset", () => {
+    setEnv(undefined, "development");
+    const log = createLogger("db");
+    log.debug("d");
+    log.info("i");
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits pretty single-line output in development", () => {
+    setEnv("debug", "development");
+    const log = createLogger("db");
+    log.info("hello", { rows: 3 });
+    const line = (stdoutSpy.mock.calls[0]?.[0] as string).trim();
+    expect(line).toContain("[db]");
+    expect(line).toContain("hello");
+    expect(line).toContain("rows");
+    expect(line).toContain("3");
+    expect(line.endsWith("\n") || line.length > 0).toBe(true);
+  });
+
+  it("emits JSON output in production", () => {
+    setEnv("debug", "production");
+    const log = createLogger("db");
+    log.info("hello", { rows: 3 });
+    const raw = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.level).toBe("info");
+    expect(parsed.tag).toBe("db");
+    expect(parsed.message).toBe("hello");
+    expect(parsed.rows).toBe(3);
+    expect(typeof parsed.timestamp).toBe("string");
+  });
+
+  it("serializes an Error passed to .error into name/message/stack", () => {
+    setEnv("debug", "production");
+    const log = createLogger("db");
+    log.error("failed", new Error("boom"));
+    const raw = stderrSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.message).toBe("failed");
+    expect(parsed.error_name).toBe("Error");
+    expect(parsed.error_message).toBe("boom");
+    expect(typeof parsed.error_stack).toBe("string");
+  });
+});

--- a/tests/server/lib/logger.test.ts
+++ b/tests/server/lib/logger.test.ts
@@ -57,16 +57,36 @@ describe("createLogger (server)", () => {
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("emits pretty single-line output in development", () => {
+  it("emits pretty single-line output in development with trailing newline", () => {
     setEnv("debug", "development");
     const log = createLogger("db");
     log.info("hello", { rows: 3 });
-    const line = (stdoutSpy.mock.calls[0]?.[0] as string).trim();
+    const raw = stdoutSpy.mock.calls[0]?.[0] as string;
+    expect(raw.endsWith("\n")).toBe(true);
+    const line = raw.trim();
     expect(line).toContain("[db]");
     expect(line).toContain("hello");
     expect(line).toContain("rows");
     expect(line).toContain("3");
-    expect(line.endsWith("\n") || line.length > 0).toBe(true);
+  });
+
+  it("lets the envelope message/level/tag win over colliding context keys in JSON output", () => {
+    setEnv("debug", "production");
+    const log = createLogger("real-tag");
+    log.info("real message", {
+      message: "user supplied",
+      level: "trace",
+      tag: "spoofed",
+      timestamp: "fake",
+      other: 1,
+    });
+    const raw = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.message).toBe("real message");
+    expect(parsed.level).toBe("info");
+    expect(parsed.tag).toBe("real-tag");
+    expect(parsed.timestamp).not.toBe("fake");
+    expect(parsed.other).toBe(1);
   });
 
   it("emits JSON output in production", () => {


### PR DESCRIPTION
## Summary
- Introduces `src/lib/logger.ts` and `server/lib/logger.ts` — level-gated structured loggers for client and server.
- Zero call-site migrations. No existing file modified.
- Unblocks packages A–E in the p1 parallel cleanup batch so they can adopt the logger for any new log lines they add.

Part of #19. Package F1 of the [p1 parallel batch spec](../blob/main/docs/superpowers/specs/2026-04-15-p1-parallel-batch-design.md).

## Test plan
- [x] `pnpm check-all` green (1441 tests pass)
- [x] `tests/lib/logger.test.ts` — 6/6 pass
- [x] `tests/server/lib/logger.test.ts` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable logging infrastructure for both client and server with runtime log-level filtering
  * Implemented structured logging system with optional context and error serialization support
  * Log output format automatically adapts based on runtime environment configuration

* **Tests**
  * Added comprehensive test coverage for logging functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->