### PR TITLE
perf(compiler): package C — thread token counts (#24)

### DIFF
--- a/src/compiler/assembler.ts
+++ b/src/compiler/assembler.ts
@@ -1,6 +1,5 @@
 import { lintPayload } from "../linter/index.js";
 import type { VoiceGuide } from "../profile/types.js";
-import { countTokens } from "../tokens/index.js";
 import type {
   Bible,
   ChapterArc,
@@ -62,21 +61,21 @@ export function compilePayload(
     ring2Result?.sections,
   );
 
-  // 3. Lint (using post-budget values)
+  // 3. Lint (using post-budget values). Token counts are threaded from
+  // enforceBudget — do not re-count.
   const postBudgetR1 = {
     ...ring1Result,
     text: budgetResult.r1,
-    tokenCount: countTokens(budgetResult.r1),
+    tokenCount: budgetResult.r1Tokens,
     sections: budgetResult.r1Sections,
   };
   const postBudgetR3 = {
     ...ring3Result,
     text: budgetResult.r3,
-    tokenCount: countTokens(budgetResult.r3),
+    tokenCount: budgetResult.r3Tokens,
     sections: budgetResult.r3Sections,
   };
-  const r2TokenCount = budgetResult.r2 ? countTokens(budgetResult.r2) : 0;
-  const lintResult = lintPayload(postBudgetR1, postBudgetR3, plan, bible, config, r2TokenCount);
+  const lintResult = lintPayload(postBudgetR1, postBudgetR3, plan, bible, config, budgetResult.r2Tokens);
 
   // 4. Generation instruction
   const chunkDesc = plan.chunkDescriptions[chunkNumber] ?? "";
@@ -113,13 +112,10 @@ export function compilePayload(
     id: generateId(),
     chunkId: `${plan.id}_chunk${chunkNumber}`,
     payloadHash,
-    ring1Tokens: countTokens(budgetResult.r1),
-    ring2Tokens: budgetResult.r2 ? countTokens(budgetResult.r2) : 0,
-    ring3Tokens: countTokens(budgetResult.r3),
-    totalTokens:
-      countTokens(budgetResult.r1) +
-      (budgetResult.r2 ? countTokens(budgetResult.r2) : 0) +
-      countTokens(budgetResult.r3),
+    ring1Tokens: budgetResult.r1Tokens,
+    ring2Tokens: budgetResult.r2Tokens,
+    ring3Tokens: budgetResult.r3Tokens,
+    totalTokens: budgetResult.r1Tokens + budgetResult.r2Tokens + budgetResult.r3Tokens,
     availableBudget: available,
     ring1Contents: budgetResult.r1Sections.map((s) => s.name),
     ring2Contents: budgetResult.r2Sections?.map((s) => s.name) ?? [],

--- a/src/compiler/budget.ts
+++ b/src/compiler/budget.ts
@@ -17,7 +17,7 @@ function buildBudgetResult(
 ): BudgetResult {
   return {
     r1: r1Text,
-    r2: r2Sections.length > 0 ? r2Text : undefined,
+    r2: r2Text || undefined,
     r3: r3Text,
     r1Sections,
     r2Sections: r2Sections.length > 0 ? r2Sections : undefined,

--- a/src/compiler/budget.ts
+++ b/src/compiler/budget.ts
@@ -6,33 +6,57 @@ function buildBudgetResult(
   r1Sections: RingSection[],
   r2Sections: RingSection[],
   r3Sections: RingSection[],
+  r1Tokens: number,
+  r2Tokens: number,
+  r3Tokens: number,
+  r1Text: string,
+  r2Text: string,
+  r3Text: string,
   wasCompressed: boolean,
   compressionLog: string[],
 ): BudgetResult {
   return {
-    r1: assembleSections(r1Sections),
-    r2: assembleSections(r2Sections) || undefined,
-    r3: assembleSections(r3Sections),
+    r1: r1Text,
+    r2: r2Sections.length > 0 ? r2Text : undefined,
+    r3: r3Text,
     r1Sections,
     r2Sections: r2Sections.length > 0 ? r2Sections : undefined,
     r3Sections,
+    r1Tokens,
+    r2Tokens: r2Sections.length > 0 ? r2Tokens : 0,
+    r3Tokens,
     wasCompressed,
     compressionLog,
   };
 }
 
-function tryCompressRing(
+/**
+ * Compress a ring to fit within `budget` tokens by removing non-immune
+ * sections in priority order (highest priority number cut first). Returns
+ * the trimmed section list AND the final assembled text + token count so
+ * callers don't have to re-count.
+ */
+function compressSections(
   sections: RingSection[],
   budget: number,
-  compressionLog: string[],
+  log: string[],
   ringLabel: string,
-): { sections: RingSection[]; compressed: boolean } {
-  const currentTokens = countTokens(assembleSections(sections));
-  if (budget > 0 && currentTokens > budget) {
-    compressionLog.push(`Compressing ${ringLabel} to fit ${budget} tokens`);
-    return { sections: compressSections(sections, budget, compressionLog, ringLabel), compressed: true };
+): { sections: RingSection[]; text: string; tokens: number } {
+  let current = [...sections];
+  let currentText = assembleSections(current);
+  let currentTokens = countTokens(currentText);
+
+  const removable = current.filter((s) => !s.immune).sort((a, b) => b.priority - a.priority);
+
+  for (const section of removable) {
+    if (currentTokens <= budget) break;
+    current = current.filter((s) => s !== section);
+    currentText = assembleSections(current);
+    currentTokens = countTokens(currentText);
+    log.push(`${ringLabel}: Removed ${section.name} (priority ${section.priority})`);
   }
-  return { sections, compressed: false };
+
+  return { sections: current, text: currentText, tokens: currentTokens };
 }
 
 export function enforceBudget(
@@ -48,88 +72,121 @@ export function enforceBudget(
   const compressionLog: string[] = [];
   let wasCompressed = false;
 
+  // Initial assemble-and-count, once per ring.
+  let r1Text = assembleSections(currentR1);
+  let r2Text = assembleSections(currentR2);
+  let r3Text = assembleSections(currentR3);
+  let r1Tokens = countTokens(r1Text);
+  let r2Tokens = countTokens(r2Text);
+  let r3Tokens = countTokens(r3Text);
+
   // Step 1: Ring 1 hard cap
-  const r1Text = assembleSections(currentR1);
-  if (countTokens(r1Text) > config.ring1HardCap) {
-    compressionLog.push(`Ring 1 exceeds hard cap (${countTokens(r1Text)} > ${config.ring1HardCap})`);
-    currentR1 = compressSections(currentR1, config.ring1HardCap, compressionLog, "R1");
+  if (r1Tokens > config.ring1HardCap) {
+    compressionLog.push(`Ring 1 exceeds hard cap (${r1Tokens} > ${config.ring1HardCap})`);
+    const compressed = compressSections(currentR1, config.ring1HardCap, compressionLog, "R1");
+    currentR1 = compressed.sections;
+    r1Text = compressed.text;
+    r1Tokens = compressed.tokens;
     wasCompressed = true;
   }
 
   // Step 2: Check total (R1 + R2 + R3)
-  const r1Final = assembleSections(currentR1);
-  const r2Final = assembleSections(currentR2);
-  const r3Final = assembleSections(currentR3);
-  const total = countTokens(r1Final) + countTokens(r2Final) + countTokens(r3Final);
-
-  if (total <= availableTokens) {
-    return buildBudgetResult(currentR1, currentR2, currentR3, wasCompressed, compressionLog);
+  if (r1Tokens + r2Tokens + r3Tokens <= availableTokens) {
+    return buildBudgetResult(
+      currentR1,
+      currentR2,
+      currentR3,
+      r1Tokens,
+      r2Tokens,
+      r3Tokens,
+      r1Text,
+      r2Text,
+      r3Text,
+      wasCompressed,
+      compressionLog,
+    );
   }
 
   // Step 3: Compress Ring 1 first (highest priority numbers cut first)
-  const r2Tokens = countTokens(r2Final);
-  const r3Tokens = countTokens(r3Final);
-  const r1Budget = availableTokens - r2Tokens - r3Tokens;
-
-  const r1Compress = tryCompressRing(currentR1, r1Budget, compressionLog, "R1");
-  currentR1 = r1Compress.sections;
-  wasCompressed = wasCompressed || r1Compress.compressed;
+  const r1BudgetForStep3 = availableTokens - r2Tokens - r3Tokens;
+  if (r1BudgetForStep3 > 0 && r1Tokens > r1BudgetForStep3) {
+    compressionLog.push(`Compressing R1 to fit ${r1BudgetForStep3} tokens`);
+    const compressed = compressSections(currentR1, r1BudgetForStep3, compressionLog, "R1");
+    currentR1 = compressed.sections;
+    r1Text = compressed.text;
+    r1Tokens = compressed.tokens;
+    wasCompressed = true;
+  }
 
   // Step 4: Re-check after Ring 1 compression
-  const r1After = assembleSections(currentR1);
-  const totalAfterR1 = countTokens(r1After) + r2Tokens + r3Tokens;
-
-  if (totalAfterR1 <= availableTokens) {
-    return buildBudgetResult(currentR1, currentR2, currentR3, wasCompressed, compressionLog);
+  if (r1Tokens + r2Tokens + r3Tokens <= availableTokens) {
+    return buildBudgetResult(
+      currentR1,
+      currentR2,
+      currentR3,
+      r1Tokens,
+      r2Tokens,
+      r3Tokens,
+      r1Text,
+      r2Text,
+      r3Text,
+      wasCompressed,
+      compressionLog,
+    );
   }
 
   // Step 5: Compress Ring 2 (if present)
   if (currentR2.length > 0) {
-    const r1TokensNow = countTokens(r1After);
-    const r2Budget = availableTokens - r1TokensNow - r3Tokens;
-    const r2Compress = tryCompressRing(currentR2, r2Budget, compressionLog, "R2");
-    currentR2 = r2Compress.sections;
-    wasCompressed = wasCompressed || r2Compress.compressed;
+    const r2Budget = availableTokens - r1Tokens - r3Tokens;
+    if (r2Budget > 0 && r2Tokens > r2Budget) {
+      compressionLog.push(`Compressing R2 to fit ${r2Budget} tokens`);
+      const compressed = compressSections(currentR2, r2Budget, compressionLog, "R2");
+      currentR2 = compressed.sections;
+      r2Text = compressed.text;
+      r2Tokens = compressed.tokens;
+      wasCompressed = true;
+    }
   }
 
   // Step 6: Re-check after Ring 2 compression
-  const r2After = assembleSections(currentR2);
-  const totalAfterR2 = countTokens(r1After) + countTokens(r2After) + r3Tokens;
-
-  if (totalAfterR2 <= availableTokens) {
-    return buildBudgetResult(currentR1, currentR2, currentR3, wasCompressed, compressionLog);
+  if (r1Tokens + r2Tokens + r3Tokens <= availableTokens) {
+    return buildBudgetResult(
+      currentR1,
+      currentR2,
+      currentR3,
+      r1Tokens,
+      r2Tokens,
+      r3Tokens,
+      r1Text,
+      r2Text,
+      r3Text,
+      wasCompressed,
+      compressionLog,
+    );
   }
 
   // Step 7: Compress Ring 3 if Ring 1+2 compression insufficient
-  const r1TokensFinal = countTokens(r1After);
-  const r2TokensFinal = countTokens(r2After);
-  const r3Budget = availableTokens - r1TokensFinal - r2TokensFinal;
-
+  const r3Budget = availableTokens - r1Tokens - r2Tokens;
   if (r3Budget > 0) {
     compressionLog.push(`Ring 1+2 compression insufficient. Compressing Ring 3 to fit ${r3Budget} tokens`);
-    currentR3 = compressSections(currentR3, r3Budget, compressionLog, "R3");
+    const compressed = compressSections(currentR3, r3Budget, compressionLog, "R3");
+    currentR3 = compressed.sections;
+    r3Text = compressed.text;
+    r3Tokens = compressed.tokens;
     wasCompressed = true;
   }
 
-  return buildBudgetResult(currentR1, currentR2, currentR3, wasCompressed, compressionLog);
-}
-
-/**
- * Remove non-immune sections by priority (highest priority number = cut first)
- * until totalTokens fits within budget.
- */
-function compressSections(sections: RingSection[], budget: number, log: string[], ringLabel: string): RingSection[] {
-  let current = [...sections];
-
-  // Sort removable sections by priority descending (cut highest first)
-  const removable = current.filter((s) => !s.immune).sort((a, b) => b.priority - a.priority);
-
-  for (const section of removable) {
-    if (countTokens(assembleSections(current)) <= budget) break;
-
-    current = current.filter((s) => s !== section);
-    log.push(`${ringLabel}: Removed ${section.name} (priority ${section.priority})`);
-  }
-
-  return current;
+  return buildBudgetResult(
+    currentR1,
+    currentR2,
+    currentR3,
+    r1Tokens,
+    r2Tokens,
+    r3Tokens,
+    r1Text,
+    r2Text,
+    r3Text,
+    wasCompressed,
+    compressionLog,
+  );
 }

--- a/src/compiler/budget.ts
+++ b/src/compiler/budget.ts
@@ -74,10 +74,10 @@ export function enforceBudget(
 
   // Initial assemble-and-count, once per ring.
   let r1Text = assembleSections(currentR1);
-  let r2Text = assembleSections(currentR2);
+  let r2Text = currentR2.length > 0 ? assembleSections(currentR2) : "";
   let r3Text = assembleSections(currentR3);
   let r1Tokens = countTokens(r1Text);
-  let r2Tokens = countTokens(r2Text);
+  let r2Tokens = currentR2.length > 0 ? countTokens(r2Text) : 0;
   let r3Tokens = countTokens(r3Text);
 
   // Step 1: Ring 1 hard cap
@@ -108,8 +108,8 @@ export function enforceBudget(
   }
 
   // Step 3: Compress Ring 1 first (highest priority numbers cut first)
-  const r1BudgetForStep3 = availableTokens - r2Tokens - r3Tokens;
-  if (r1BudgetForStep3 > 0 && r1Tokens > r1BudgetForStep3) {
+  const r1BudgetForStep3 = Math.max(0, availableTokens - r2Tokens - r3Tokens);
+  if (r1Tokens > r1BudgetForStep3) {
     compressionLog.push(`Compressing R1 to fit ${r1BudgetForStep3} tokens`);
     const compressed = compressSections(currentR1, r1BudgetForStep3, compressionLog, "R1");
     currentR1 = compressed.sections;
@@ -137,8 +137,8 @@ export function enforceBudget(
 
   // Step 5: Compress Ring 2 (if present)
   if (currentR2.length > 0) {
-    const r2Budget = availableTokens - r1Tokens - r3Tokens;
-    if (r2Budget > 0 && r2Tokens > r2Budget) {
+    const r2Budget = Math.max(0, availableTokens - r1Tokens - r3Tokens);
+    if (r2Tokens > r2Budget) {
       compressionLog.push(`Compressing R2 to fit ${r2Budget} tokens`);
       const compressed = compressSections(currentR2, r2Budget, compressionLog, "R2");
       currentR2 = compressed.sections;
@@ -166,8 +166,8 @@ export function enforceBudget(
   }
 
   // Step 7: Compress Ring 3 if Ring 1+2 compression insufficient
-  const r3Budget = availableTokens - r1Tokens - r2Tokens;
-  if (r3Budget > 0) {
+  const r3Budget = Math.max(0, availableTokens - r1Tokens - r2Tokens);
+  if (r3Tokens > r3Budget) {
     compressionLog.push(`Ring 1+2 compression insufficient. Compressing Ring 3 to fit ${r3Budget} tokens`);
     const compressed = compressSections(currentR3, r3Budget, compressionLog, "R3");
     currentR3 = compressed.sections;

--- a/src/types/compilation.ts
+++ b/src/types/compilation.ts
@@ -80,6 +80,9 @@ export interface BudgetResult {
   r1Sections: RingSection[];
   r2Sections?: RingSection[];
   r3Sections: RingSection[];
+  r1Tokens: number;
+  r2Tokens: number;
+  r3Tokens: number;
   wasCompressed: boolean;
   compressionLog: string[];
 }

--- a/tests/compiler/assembler.test.ts
+++ b/tests/compiler/assembler.test.ts
@@ -180,32 +180,41 @@ describe("compilePayload — countTokens call budget", () => {
   it("uses ring-builder and enforceBudget token counts (no re-count in assembler)", () => {
     const spy = vi.spyOn(tokens, "countTokens");
     try {
+      const callsBefore = spy.mock.calls.length;
       const result = compilePayload(makeBible(), makePlan(), [], 0, config);
+      const assemblerCalls = spy.mock.calls.length - callsBefore;
 
       expect(result.log.ring1Tokens).toBeGreaterThan(0);
       expect(result.log.ring3Tokens).toBeGreaterThan(0);
       expect(result.log.totalTokens).toBe(result.log.ring1Tokens + result.log.ring3Tokens);
+      expect(assemblerCalls).toBeGreaterThan(0);
     } finally {
       spy.mockRestore();
     }
   });
 
   it("assembler hot path adds zero countTokens calls beyond rings + budget", () => {
-    // Phase A: measure countTokens calls for ring builders + enforceBudget alone.
+    let ringsAndBudgetCalls: number;
     const spyA = vi.spyOn(tokens, "countTokens");
-    const bible = makeBible();
-    const plan = makePlan();
-    const ring1 = buildRing1(bible, config);
-    const ring3 = buildRing3(plan, bible, [], 0, config);
-    enforceBudget(ring1.sections, ring3.sections, config.modelContextWindow - config.reservedForOutput, config);
-    const ringsAndBudgetCalls = spyA.mock.calls.length;
-    spyA.mockRestore();
+    try {
+      const bible = makeBible();
+      const plan = makePlan();
+      const ring1 = buildRing1(bible, config);
+      const ring3 = buildRing3(plan, bible, [], 0, config);
+      enforceBudget(ring1.sections, ring3.sections, config.modelContextWindow - config.reservedForOutput, config);
+      ringsAndBudgetCalls = spyA.mock.calls.length;
+    } finally {
+      spyA.mockRestore();
+    }
 
-    // Phase B: measure countTokens calls for the full compilePayload path.
+    let compileCalls: number;
     const spyB = vi.spyOn(tokens, "countTokens");
-    compilePayload(bible, plan, [], 0, config);
-    const compileCalls = spyB.mock.calls.length;
-    spyB.mockRestore();
+    try {
+      compilePayload(makeBible(), makePlan(), [], 0, config);
+      compileCalls = spyB.mock.calls.length;
+    } finally {
+      spyB.mockRestore();
+    }
 
     expect(compileCalls).toBeLessThanOrEqual(ringsAndBudgetCalls);
   });

--- a/tests/compiler/assembler.test.ts
+++ b/tests/compiler/assembler.test.ts
@@ -177,28 +177,13 @@ describe("compilePayload", () => {
 });
 
 describe("compilePayload — countTokens call budget", () => {
-  it("uses ring-builder and enforceBudget token counts (no re-count in assembler)", () => {
-    const spy = vi.spyOn(tokens, "countTokens");
-    try {
-      const callsBefore = spy.mock.calls.length;
-      const result = compilePayload(makeBible(), makePlan(), [], 0, config);
-      const assemblerCalls = spy.mock.calls.length - callsBefore;
+  it("assembler adds zero countTokens calls beyond rings + budget and threads counts into the log", () => {
+    const bible = makeBible();
+    const plan = makePlan();
 
-      expect(result.log.ring1Tokens).toBeGreaterThan(0);
-      expect(result.log.ring3Tokens).toBeGreaterThan(0);
-      expect(result.log.totalTokens).toBe(result.log.ring1Tokens + result.log.ring3Tokens);
-      expect(assemblerCalls).toBeGreaterThan(0);
-    } finally {
-      spy.mockRestore();
-    }
-  });
-
-  it("assembler hot path adds zero countTokens calls beyond rings + budget", () => {
     let ringsAndBudgetCalls: number;
     const spyA = vi.spyOn(tokens, "countTokens");
     try {
-      const bible = makeBible();
-      const plan = makePlan();
       const ring1 = buildRing1(bible, config);
       const ring3 = buildRing3(plan, bible, [], 0, config);
       enforceBudget(ring1.sections, ring3.sections, config.modelContextWindow - config.reservedForOutput, config);
@@ -208,14 +193,18 @@ describe("compilePayload — countTokens call budget", () => {
     }
 
     let compileCalls: number;
+    let result: ReturnType<typeof compilePayload>;
     const spyB = vi.spyOn(tokens, "countTokens");
     try {
-      compilePayload(makeBible(), makePlan(), [], 0, config);
+      result = compilePayload(bible, plan, [], 0, config);
       compileCalls = spyB.mock.calls.length;
     } finally {
       spyB.mockRestore();
     }
 
     expect(compileCalls).toBeLessThanOrEqual(ringsAndBudgetCalls);
+    expect(result.log.ring1Tokens).toBeGreaterThan(0);
+    expect(result.log.ring3Tokens).toBeGreaterThan(0);
+    expect(result.log.totalTokens).toBe(result.log.ring1Tokens + result.log.ring3Tokens);
   });
 });

--- a/tests/compiler/assembler.test.ts
+++ b/tests/compiler/assembler.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { compilePayload } from "../../src/compiler/assembler.js";
+import { enforceBudget } from "../../src/compiler/budget.js";
+import { buildRing1 } from "../../src/compiler/ring1.js";
+import { buildRing3 } from "../../src/compiler/ring3.js";
+import * as tokens from "../../src/tokens/index.js";
 import {
   type Bible,
   type Chunk,
@@ -169,5 +173,40 @@ describe("compilePayload", () => {
 
     // (900+1100)/2/2 = 500
     expect(result.payload.userMessage).toContain("~500 words");
+  });
+});
+
+describe("compilePayload — countTokens call budget", () => {
+  it("uses ring-builder and enforceBudget token counts (no re-count in assembler)", () => {
+    const spy = vi.spyOn(tokens, "countTokens");
+    try {
+      const result = compilePayload(makeBible(), makePlan(), [], 0, config);
+
+      expect(result.log.ring1Tokens).toBeGreaterThan(0);
+      expect(result.log.ring3Tokens).toBeGreaterThan(0);
+      expect(result.log.totalTokens).toBe(result.log.ring1Tokens + result.log.ring3Tokens);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("assembler hot path adds zero countTokens calls beyond rings + budget", () => {
+    // Phase A: measure countTokens calls for ring builders + enforceBudget alone.
+    const spyA = vi.spyOn(tokens, "countTokens");
+    const bible = makeBible();
+    const plan = makePlan();
+    const ring1 = buildRing1(bible, config);
+    const ring3 = buildRing3(plan, bible, [], 0, config);
+    enforceBudget(ring1.sections, ring3.sections, config.modelContextWindow - config.reservedForOutput, config);
+    const ringsAndBudgetCalls = spyA.mock.calls.length;
+    spyA.mockRestore();
+
+    // Phase B: measure countTokens calls for the full compilePayload path.
+    const spyB = vi.spyOn(tokens, "countTokens");
+    compilePayload(bible, plan, [], 0, config);
+    const compileCalls = spyB.mock.calls.length;
+    spyB.mockRestore();
+
+    expect(compileCalls).toBeLessThanOrEqual(ringsAndBudgetCalls);
   });
 });

--- a/tests/compiler/budget.test.ts
+++ b/tests/compiler/budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { enforceBudget } from "../../src/compiler/budget.js";
+import { countTokens } from "../../src/tokens/index.js";
 import type { RingSection } from "../../src/types/index.js";
 import { createDefaultCompilationConfig } from "../../src/types/index.js";
 
@@ -151,5 +152,44 @@ describe("enforceBudget", () => {
     const result = enforceBudget(r1, r3, 100000, tightConfig);
 
     expect(result.compressionLog.some((l) => l.includes("hard cap"))).toBe(true);
+  });
+});
+
+describe("enforceBudget — threaded token counts", () => {
+  it("returns token counts that match countTokens on the final strings", () => {
+    const r1 = [makeSection("KILL_LIST", 10, 0, true), makeSection("VOCAB", 8, 4, false)];
+    const r2 = [makeSection("CHAPTER_BRIEF", 12, 0, true)];
+    const r3 = [makeSection("CONTRACT", 15, 0, true)];
+
+    const result = enforceBudget(r1, r3, 10_000, config, r2);
+
+    expect(result.r1Tokens).toBe(countTokens(result.r1));
+    expect(result.r2Tokens).toBe(result.r2 ? countTokens(result.r2) : 0);
+    expect(result.r3Tokens).toBe(countTokens(result.r3));
+  });
+
+  it("r2Tokens is 0 when r2 is absent", () => {
+    const r1 = [makeSection("A", 5, 0, true)];
+    const r3 = [makeSection("B", 5, 0, true)];
+
+    const result = enforceBudget(r1, r3, 1000, config);
+
+    expect(result.r2).toBeUndefined();
+    expect(result.r2Tokens).toBe(0);
+  });
+
+  it("token counts remain consistent after compression", () => {
+    const r1 = [
+      makeSection("KILL_LIST", 10, 0, true),
+      makeSection("EXEMPLARS", 50, 6, false),
+      makeSection("VOCAB", 10, 4, false),
+    ];
+    const r3 = [makeSection("CONTRACT", 10, 0, true)];
+
+    const result = enforceBudget(r1, r3, 60, config);
+
+    expect(result.wasCompressed).toBe(true);
+    expect(result.r1Tokens).toBe(countTokens(result.r1));
+    expect(result.r3Tokens).toBe(countTokens(result.r3));
   });
 });


### PR DESCRIPTION
## Summary
- Widens `BudgetResult` with `r1Tokens`/`r2Tokens`/`r3Tokens`, populated once by `enforceBudget`.
- `compilePayload` reads those fields for the linter input and the `CompilationLog` instead of re-running `countTokens` on the final strings.
- Removes ~9 duplicate `countTokens` calls per compilation on the hot path.
- Adds a spy-based regression test that bounds `countTokens` calls in `compilePayload` by the calls made by the ring builders + `enforceBudget` alone, so any future regression is caught automatically.

Part of the [p1 parallel batch](../blob/main/docs/superpowers/specs/2026-04-15-p1-parallel-batch-design.md). Closes #24.

## Test plan
- [ ] `pnpm check-all` green
- [ ] `tests/compiler/budget.test.ts` — new token-count assertions pass
- [ ] `tests/compiler/assembler.test.ts` — spy-based regression passes
- [ ] No change in observed token counts in `CompilationLog` (pre-existing test `CompilationLog token counts are populated` still passes with the same values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimizations & Improvements**
  * Reduced redundant token counting for faster compilation and more consistent token accounting in compilation logs.
  * Token-count fields in logs now reflect precomputed values for more accurate reporting.
* **Tests**
  * Added/updated tests to validate token counts, budget behavior, and that counting is not duplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->