### PR TITLE
test: package E — coverage for untested routes and stores (#36)

### DIFF
--- a/tests/helpers/apiTestAppWithAnthropic.ts
+++ b/tests/helpers/apiTestAppWithAnthropic.ts
@@ -1,0 +1,34 @@
+// TODO(#36/A follow-up): If Package A lands and adds runMigrations(db) to
+// apiTestApp.ts schema boot, mirror that call here.
+import Database from "better-sqlite3";
+import express from "express";
+import { createApiRouter } from "../../server/api/routes.js";
+import { createSchema } from "../../server/db/schema.js";
+
+/**
+ * Minimal Anthropic client stub accepted by server/api/routes.ts.
+ *
+ * The route code only checks `anthropicClient` for truthiness before
+ * delegating to server/profile/* functions. Those functions are mocked
+ * at the test-file level via vi.mock(), so this object never actually
+ * receives a call — it only needs to exist and be typed loosely.
+ */
+export function makeAnthropicStub(): unknown {
+  return {
+    // Shape is irrelevant; real calls are vi.mocked at the importer.
+    messages: { create: async () => ({}) },
+  };
+}
+
+export function makeApiTestAppWithAnthropic() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  createSchema(db);
+
+  const app = express();
+  app.use(express.json());
+  // biome-ignore lint/suspicious/noExplicitAny: test stub
+  app.use("/api", createApiRouter(db, makeAnthropicStub() as any));
+
+  return { app, db };
+}

--- a/tests/helpers/apiTestAppWithAnthropic.ts
+++ b/tests/helpers/apiTestAppWithAnthropic.ts
@@ -27,7 +27,6 @@ export function makeApiTestAppWithAnthropic() {
 
   const app = express();
   app.use(express.json());
-  // biome-ignore lint/suspicious/noExplicitAny: test stub
   app.use("/api", createApiRouter(db, makeAnthropicStub() as any));
 
   return { app, db };

--- a/tests/helpers/serverFactories.ts
+++ b/tests/helpers/serverFactories.ts
@@ -1,0 +1,62 @@
+import type { PreferenceStatement, SignificantEdit, VoiceGuide, WritingSample } from "../../src/profile/types.js";
+
+export function makeVoiceGuide(overrides: Partial<VoiceGuide> = {}): VoiceGuide {
+  return {
+    version: "1.0.0",
+    versionHistory: [],
+    corpusSize: 0,
+    domainsRepresented: [],
+    coreFeatures: [],
+    probableFeatures: [],
+    formatVariantFeatures: [],
+    domainSpecificFeatures: [],
+    avoidancePatterns: [],
+    narrativeSummary: "",
+    generationInstructions: "",
+    editingInstructions: "",
+    confidenceNotes: "",
+    ring1Injection: "Write in a literary voice.",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeWritingSample(overrides: Partial<WritingSample> = {}): WritingSample {
+  return {
+    id: `ws-${Math.random().toString(36).slice(2, 10)}`,
+    filename: "sample.md",
+    domain: "fiction",
+    text: "Sample prose body.",
+    wordCount: 3,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeSignificantEdit(overrides: Partial<SignificantEdit> = {}): SignificantEdit {
+  return {
+    id: `se-${Math.random().toString(36).slice(2, 10)}`,
+    projectId: "proj-test",
+    chunkId: "c1",
+    originalText: "before",
+    editedText: "after",
+    processed: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeProjectVoiceGuide(overrides: Partial<VoiceGuide> = {}): VoiceGuide {
+  return makeVoiceGuide({ ring1Injection: "Project-scoped voice.", ...overrides });
+}
+
+export function makePreferenceStatement(overrides: Partial<PreferenceStatement> = {}): PreferenceStatement {
+  return {
+    id: `ps-${Math.random().toString(36).slice(2, 10)}`,
+    projectId: "proj-test",
+    statement: "Prefer concise dialogue tags.",
+    editCount: 1,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/tests/helpers/silenceConsole.ts
+++ b/tests/helpers/silenceConsole.ts
@@ -1,0 +1,9 @@
+import { vi } from "vitest";
+
+/** Silence the four console methods that server route handlers touch. */
+export function silenceConsole(): void {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "debug").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+}

--- a/tests/helpers/unwrap.ts
+++ b/tests/helpers/unwrap.ts
@@ -1,0 +1,22 @@
+import type { Response } from "supertest";
+
+/**
+ * Envelope-agnostic body reader for route tests.
+ *
+ * Pre-envelope (current `main`): returns `res.body` as-is.
+ * Post-envelope (Package B landed): unwraps `{ ok, data }` and throws on
+ * `{ ok: false, error }`.
+ *
+ * Package B's author swaps the implementation in their PR; all
+ * ~30+ call sites across Package E's new tests stay unchanged.
+ */
+export function unwrap<T>(res: Response): T {
+  if (res.body && typeof res.body === "object" && "ok" in res.body) {
+    if ((res.body as { ok: boolean }).ok === true) {
+      return (res.body as { data: T }).data;
+    }
+    const err = (res.body as { error?: { code?: string; message?: string } }).error ?? {};
+    throw new Error(`API error: ${err.code ?? "UNKNOWN"}: ${err.message ?? ""}`);
+  }
+  return res.body as T;
+}

--- a/tests/server/routes/cipher-batch.test.ts
+++ b/tests/server/routes/cipher-batch.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as significantEditsRepo from "../../../server/db/repositories/significant-edits.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeApiTestAppWithAnthropic } from "../../helpers/apiTestAppWithAnthropic.js";
+import { makeSignificantEdit } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+// IMPORTANT: the returned statement object must match every column in the
+// `preference_statements` table, because the route calls
+// preferenceStatementsRepo.createPreferenceStatement(db, statement) which
+// runs a real INSERT. Required columns per
+// `server/db/repositories/preference-statements.ts`:
+//   id, projectId, statement, editCount, createdAt
+vi.mock("../../../server/profile/cipher.js", () => ({
+  CIPHER_BATCH_SIZE: 10,
+  inferBatchPreferences: vi.fn(async (_client: unknown, projectId: string) => ({
+    id: "stmt-1",
+    projectId,
+    statement: "Mocked preference statement.",
+    editCount: 1,
+    createdAt: new Date().toISOString(),
+  })),
+}));
+
+vi.mock("../../../server/profile/projectGuide.js", () => ({
+  updateProjectVoice: vi.fn(async () => ({ ring1Injection: "updated" })),
+  distillVoice: vi.fn(async () => "redistilled ring1 injection"),
+}));
+
+beforeEach(() => {
+  silenceConsole();
+});
+
+describe("POST /api/projects/:projectId/cipher/batch", () => {
+  it("returns { statement: null } when there are no unprocessed edits", async () => {
+    const { app } = makeApiTestAppWithAnthropic();
+    const res = await request(app).post("/api/projects/proj-empty/cipher/batch");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ statement: null }>(res);
+    expect(body).toEqual({ statement: null });
+  });
+
+  it("returns 500 when Anthropic client is not configured", async () => {
+    const { app, db } = makeApiTestApp();
+    // Ensure project exists (FK constraint on significant_edits.project_id).
+    db.prepare("INSERT INTO projects (id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)").run(
+      "proj-x",
+      "Test",
+      "drafting",
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    const edit = makeSignificantEdit({ id: "e1", projectId: "proj-x" });
+    significantEditsRepo.createSignificantEdit(db, edit);
+    const res = await request(app).post("/api/projects/proj-x/cipher/batch");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Anthropic");
+  });
+
+  it("returns 201 with statement and marks edits processed on success", async () => {
+    const { app, db } = makeApiTestAppWithAnthropic();
+    // Ensure project exists (FK constraint on significant_edits.project_id).
+    db.prepare("INSERT INTO projects (id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)").run(
+      "proj-y",
+      "Test",
+      "drafting",
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    const edit = makeSignificantEdit({ id: "e2", projectId: "proj-y" });
+    significantEditsRepo.createSignificantEdit(db, edit);
+
+    const res = await request(app).post("/api/projects/proj-y/cipher/batch");
+    expect(res.status).toBe(201);
+    const body = unwrap<{ statement: { statement: string }; ring1Injection: string }>(res);
+    expect(body.statement).toBeDefined();
+    expect(body.statement.statement).toBe("Mocked preference statement.");
+    expect(body.ring1Injection).toBe("redistilled ring1 injection");
+
+    // Edits marked processed
+    const remaining = significantEditsRepo.listUnprocessedEdits(db, "proj-y");
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/tests/server/routes/project-voice-guide-get.test.ts
+++ b/tests/server/routes/project-voice-guide-get.test.ts
@@ -1,0 +1,45 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as projectVoiceGuideRepo from "../../../server/db/repositories/project-voice-guide.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeVoiceGuide } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("GET /api/projects/:projectId/project-voice-guide", () => {
+  it("returns { guide: null } when no guide is saved for the project", async () => {
+    const res = await request(app).get("/api/projects/no-guide/project-voice-guide");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ guide: null }>(res);
+    expect(body).toEqual({ guide: null });
+  });
+
+  it("returns the saved guide when present", async () => {
+    // Ensure project exists (FK constraint on project_voice_guide.project_id).
+    db.prepare("INSERT INTO projects (id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)").run(
+      "proj-42",
+      "Test",
+      "drafting",
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    const guide = makeVoiceGuide({ ring1Injection: "project voice" });
+    projectVoiceGuideRepo.saveProjectVoiceGuide(db, "proj-42", guide);
+
+    const res = await request(app).get("/api/projects/proj-42/project-voice-guide");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ guide: { ring1Injection: string } }>(res);
+    expect(body.guide).not.toBeNull();
+    expect(body.guide.ring1Injection).toBe("project voice");
+  });
+});

--- a/tests/server/routes/project-voice-guide-update.test.ts
+++ b/tests/server/routes/project-voice-guide-update.test.ts
@@ -1,0 +1,76 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as projectVoiceGuideRepo from "../../../server/db/repositories/project-voice-guide.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeApiTestAppWithAnthropic } from "../../helpers/apiTestAppWithAnthropic.js";
+import { makeVoiceGuide } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+const updateProjectVoice = vi.fn();
+const distillVoice = vi.fn();
+
+vi.mock("../../../server/profile/projectGuide.js", () => ({
+  updateProjectVoice: (...args: unknown[]) => updateProjectVoice(...args),
+  distillVoice: (...args: unknown[]) => distillVoice(...args),
+}));
+
+beforeEach(() => {
+  updateProjectVoice.mockReset();
+  distillVoice.mockReset();
+  silenceConsole();
+});
+
+describe("POST /api/projects/:projectId/project-voice-guide/update", () => {
+  it("returns 500 when Anthropic client is not configured", async () => {
+    const { app } = makeApiTestApp();
+    const res = await request(app)
+      .post("/api/projects/p/project-voice-guide/update")
+      .send({ sceneId: "s1", sceneText: "Text." });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Anthropic");
+  });
+
+  it("returns 201 with updated project guide and distilled injection", async () => {
+    const guide = makeVoiceGuide({ ring1Injection: "new project voice" });
+    updateProjectVoice.mockResolvedValue(guide);
+    distillVoice.mockResolvedValue("final distilled");
+
+    const { app, db } = makeApiTestAppWithAnthropic();
+    // Ensure project exists (FK constraint on project_voice_guide.project_id).
+    db.prepare("INSERT INTO projects (id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)").run(
+      "proj-upd",
+      "Test",
+      "drafting",
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    const res = await request(app)
+      .post("/api/projects/proj-upd/project-voice-guide/update")
+      .send({ sceneId: "s1", sceneText: "Scene prose." });
+
+    expect(res.status).toBe(201);
+    const body = unwrap<{ projectGuide: { ring1Injection: string }; ring1Injection: string }>(res);
+    expect(body.projectGuide.ring1Injection).toBe("new project voice");
+    expect(body.ring1Injection).toBe("final distilled");
+    expect(updateProjectVoice).toHaveBeenCalledTimes(1);
+    expect(distillVoice).toHaveBeenCalledTimes(1);
+
+    // Verify the DB side effect.
+    const stored = projectVoiceGuideRepo.getProjectVoiceGuide(db, "proj-upd");
+    expect(stored).not.toBeNull();
+    expect(stored!.ring1Injection).toBe("new project voice");
+  });
+
+  it("returns 500 when a downstream profile call throws", async () => {
+    updateProjectVoice.mockRejectedValue(new Error("profile crash"));
+
+    const { app } = makeApiTestAppWithAnthropic();
+    const res = await request(app)
+      .post("/api/projects/proj-err/project-voice-guide/update")
+      .send({ sceneId: "s2", sceneText: "x" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("profile crash");
+  });
+});

--- a/tests/server/routes/significant-edits.test.ts
+++ b/tests/server/routes/significant-edits.test.ts
@@ -1,0 +1,58 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as significantEditsRepo from "../../../server/db/repositories/significant-edits.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("POST /api/projects/:projectId/significant-edits", () => {
+  it("creates an edit and returns the unprocessed count", async () => {
+    const res = await request(app)
+      .post("/api/projects/proj-1/significant-edits")
+      .send({ chunkId: "c-1", originalText: "Before edit.", editedText: "After edit." });
+
+    expect(res.status).toBe(201);
+    const body = unwrap<{ count: number }>(res);
+    expect(body.count).toBe(1);
+
+    const stored = significantEditsRepo.listUnprocessedEdits(db, "proj-1");
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.originalText).toBe("Before edit.");
+    expect(stored[0]!.editedText).toBe("After edit.");
+    expect(stored[0]!.processed).toBe(false);
+    expect(stored[0]!.id).toBeDefined();
+  });
+
+  it("increments the count for subsequent edits on the same project", async () => {
+    await request(app)
+      .post("/api/projects/proj-2/significant-edits")
+      .send({ chunkId: "c-a", originalText: "o1", editedText: "e1" });
+    const res = await request(app)
+      .post("/api/projects/proj-2/significant-edits")
+      .send({ chunkId: "c-b", originalText: "o2", editedText: "e2" });
+
+    expect(res.status).toBe(201);
+    const body = unwrap<{ count: number }>(res);
+    expect(body.count).toBe(2);
+  });
+
+  it("auto-creates the project row if it does not exist yet", async () => {
+    const res = await request(app)
+      .post("/api/projects/auto-created/significant-edits")
+      .send({ chunkId: "c-x", originalText: "a", editedText: "b" });
+
+    expect(res.status).toBe(201);
+    const projectRow = db.prepare("SELECT id FROM projects WHERE id = ?").get("auto-created");
+    expect(projectRow).toBeDefined();
+  });
+});

--- a/tests/server/routes/voice-guide-generate.test.ts
+++ b/tests/server/routes/voice-guide-generate.test.ts
@@ -34,7 +34,9 @@ describe("POST /api/voice-guide/generate", () => {
 
   it("returns 404 when no writing samples match the supplied IDs", async () => {
     const { app } = makeApiTestAppWithAnthropic();
-    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: ["nonexistent-id"] });
+    const res = await request(app)
+      .post("/api/voice-guide/generate")
+      .send({ sampleIds: ["nonexistent-id"] });
     expect(res.status).toBe(404);
     expect(res.body.error).toContain("No writing samples");
   });
@@ -44,7 +46,9 @@ describe("POST /api/voice-guide/generate", () => {
     const sample = makeWritingSample({ id: "s1" });
     writingSampleRepo.createWritingSampleRecord(db, sample);
 
-    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: [sample.id] });
+    const res = await request(app)
+      .post("/api/voice-guide/generate")
+      .send({ sampleIds: [sample.id] });
     expect(res.status).toBe(500);
     expect(res.body.error).toContain("Anthropic");
   });
@@ -54,7 +58,9 @@ describe("POST /api/voice-guide/generate", () => {
     const { app, db } = makeApiTestAppWithAnthropic();
     const sample = makeWritingSample({ id: "s-throw" });
     writingSampleRepo.createWritingSampleRecord(db, sample);
-    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: ["s-throw"] });
+    const res = await request(app)
+      .post("/api/voice-guide/generate")
+      .send({ sampleIds: ["s-throw"] });
     expect(res.status).toBe(500);
     const body = res.body as { error?: string | { message?: string } };
     const msg = typeof body.error === "string" ? body.error : body.error?.message;
@@ -66,7 +72,9 @@ describe("POST /api/voice-guide/generate", () => {
     const sample = makeWritingSample({ id: "s2" });
     writingSampleRepo.createWritingSampleRecord(db, sample);
 
-    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: [sample.id] });
+    const res = await request(app)
+      .post("/api/voice-guide/generate")
+      .send({ sampleIds: [sample.id] });
     expect(res.status).toBe(201);
     expect(res.body.ring1Injection).toBe("generated injection");
   });

--- a/tests/server/routes/voice-guide-generate.test.ts
+++ b/tests/server/routes/voice-guide-generate.test.ts
@@ -1,0 +1,73 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as writingSampleRepo from "../../../server/db/repositories/writing-samples.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeApiTestAppWithAnthropic } from "../../helpers/apiTestAppWithAnthropic.js";
+import { makeVoiceGuide, makeWritingSample } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+
+const runPipeline = vi.fn();
+
+vi.mock("../../../server/profile/pipeline.js", () => ({
+  runPipeline: (...args: unknown[]) => runPipeline(...args),
+}));
+
+beforeEach(() => {
+  silenceConsole();
+  runPipeline.mockReset();
+  runPipeline.mockResolvedValue(makeVoiceGuide({ ring1Injection: "generated injection" }));
+});
+
+describe("POST /api/voice-guide/generate", () => {
+  it("returns 400 when sampleIds is missing", async () => {
+    const { app } = makeApiTestApp();
+    const res = await request(app).post("/api/voice-guide/generate").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("sampleIds");
+  });
+
+  it("returns 400 when sampleIds is an empty array", async () => {
+    const { app } = makeApiTestApp();
+    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when no writing samples match the supplied IDs", async () => {
+    const { app } = makeApiTestAppWithAnthropic();
+    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: ["nonexistent-id"] });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("No writing samples");
+  });
+
+  it("returns 500 when Anthropic client is not configured", async () => {
+    const { app, db } = makeApiTestApp();
+    const sample = makeWritingSample({ id: "s1" });
+    writingSampleRepo.createWritingSampleRecord(db, sample);
+
+    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: [sample.id] });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Anthropic");
+  });
+
+  it("returns 500 when runPipeline throws", async () => {
+    runPipeline.mockRejectedValueOnce(new Error("pipeline crash"));
+    const { app, db } = makeApiTestAppWithAnthropic();
+    const sample = makeWritingSample({ id: "s-throw" });
+    writingSampleRepo.createWritingSampleRecord(db, sample);
+    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: ["s-throw"] });
+    expect(res.status).toBe(500);
+    const body = res.body as { error?: string | { message?: string } };
+    const msg = typeof body.error === "string" ? body.error : body.error?.message;
+    expect(msg).toContain("pipeline crash");
+  });
+
+  it("returns 201 with generated guide when pipeline succeeds", async () => {
+    const { app, db } = makeApiTestAppWithAnthropic();
+    const sample = makeWritingSample({ id: "s2" });
+    writingSampleRepo.createWritingSampleRecord(db, sample);
+
+    const res = await request(app).post("/api/voice-guide/generate").send({ sampleIds: [sample.id] });
+    expect(res.status).toBe(201);
+    expect(res.body.ring1Injection).toBe("generated injection");
+  });
+});

--- a/tests/server/routes/voice-guide-get.test.ts
+++ b/tests/server/routes/voice-guide-get.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as voiceGuideRepo from "../../../server/db/repositories/voice-guide.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeVoiceGuide } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("GET /api/voice-guide", () => {
+  it("returns { guide: null } when no voice guide exists", async () => {
+    const res = await request(app).get("/api/voice-guide");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ guide: null }>(res);
+    expect(body).toEqual({ guide: null });
+  });
+
+  it("returns { guide } when a guide exists", async () => {
+    const guide = makeVoiceGuide({ ring1Injection: "Write in a literary voice." });
+    voiceGuideRepo.saveVoiceGuide(db, guide);
+
+    const res = await request(app).get("/api/voice-guide");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ guide: { ring1Injection: string } }>(res);
+    expect(body.guide).not.toBeNull();
+    expect(body.guide.ring1Injection).toBe("Write in a literary voice.");
+  });
+});

--- a/tests/server/routes/voice-guide-versions.test.ts
+++ b/tests/server/routes/voice-guide-versions.test.ts
@@ -1,0 +1,65 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as voiceGuideRepo from "../../../server/db/repositories/voice-guide.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeVoiceGuide } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("GET /api/voice-guide/versions", () => {
+  it("returns an empty array when no versions exist", async () => {
+    const res = await request(app).get("/api/voice-guide/versions");
+    expect(res.status).toBe(200);
+    const body = unwrap<unknown[]>(res);
+    expect(body).toEqual([]);
+  });
+
+  it("lists saved voice-guide versions", async () => {
+    const guide1 = makeVoiceGuide({
+      version: "1.0.0",
+      versionHistory: [
+        {
+          version: "1.0.0",
+          updatedAt: "2024-01-01T00:00:00Z",
+          changeReason: "Initial",
+          changeSummary: "First version",
+          confirmedFeatures: [],
+          contradictedFeatures: [],
+          newFeatures: [],
+        },
+      ],
+    });
+    const guide2 = makeVoiceGuide({
+      version: "2.0.0",
+      versionHistory: [
+        {
+          version: "2.0.0",
+          updatedAt: "2024-02-01T00:00:00Z",
+          changeReason: "Update",
+          changeSummary: "Second version",
+          confirmedFeatures: [],
+          contradictedFeatures: [],
+          newFeatures: [],
+        },
+      ],
+    });
+    voiceGuideRepo.saveVoiceGuideVersion(db, guide1);
+    voiceGuideRepo.saveVoiceGuideVersion(db, guide2);
+
+    const res = await request(app).get("/api/voice-guide/versions");
+    expect(res.status).toBe(200);
+    const body = unwrap<unknown[]>(res);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(2);
+  });
+});

--- a/tests/server/routes/voice-redistill.test.ts
+++ b/tests/server/routes/voice-redistill.test.ts
@@ -1,0 +1,45 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as voiceGuideRepo from "../../../server/db/repositories/voice-guide.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeApiTestAppWithAnthropic } from "../../helpers/apiTestAppWithAnthropic.js";
+import { makeVoiceGuide } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+vi.mock("../../../server/profile/projectGuide.js", () => ({
+  updateProjectVoice: vi.fn(),
+  distillVoice: vi.fn(async () => "distilled output"),
+}));
+
+beforeEach(() => {
+  silenceConsole();
+});
+
+describe("POST /api/projects/:projectId/voice/redistill", () => {
+  it("returns 500 when Anthropic client is not configured", async () => {
+    const { app } = makeApiTestApp();
+    const res = await request(app).post("/api/projects/p/voice/redistill");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Anthropic");
+  });
+
+  it("returns { skipped: true } when there are no sources at all", async () => {
+    const { app } = makeApiTestAppWithAnthropic();
+    const res = await request(app).post("/api/projects/empty-proj/voice/redistill");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ ring1Injection: string; skipped: boolean }>(res);
+    expect(body).toEqual({ ring1Injection: "", skipped: true });
+  });
+
+  it("returns the distilled ring1Injection when a source exists", async () => {
+    const { app, db } = makeApiTestAppWithAnthropic();
+    const guide = makeVoiceGuide({ ring1Injection: "existing" });
+    voiceGuideRepo.saveVoiceGuide(db, guide);
+
+    const res = await request(app).post("/api/projects/proj-rd/voice/redistill");
+    expect(res.status).toBe(200);
+    const body = unwrap<{ ring1Injection: string }>(res);
+    expect(body.ring1Injection).toBe("distilled output");
+  });
+});

--- a/tests/server/routes/writing-samples-create.test.ts
+++ b/tests/server/routes/writing-samples-create.test.ts
@@ -1,0 +1,46 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as writingSampleRepo from "../../../server/db/repositories/writing-samples.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("POST /api/writing-samples", () => {
+  it("creates a writing sample and returns 201 with the persisted row", async () => {
+    const res = await request(app)
+      .post("/api/writing-samples")
+      .send({ filename: "story.md", domain: "fiction", text: "One two three four." });
+
+    expect(res.status).toBe(201);
+    const body = unwrap<{ id: string; domain: string; filename: string; wordCount: number }>(res);
+    expect(body.id).toBeDefined();
+    expect(body.domain).toBe("fiction");
+    expect(body.filename).toBe("story.md");
+    // Known input "One two three four." -> 4 words.
+    expect(body.wordCount).toBe(4);
+
+    const stored = writingSampleRepo.listWritingSamples(db);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.id).toBe(body.id);
+  });
+
+  it("accepts a missing filename (defaults to null)", async () => {
+    const res = await request(app)
+      .post("/api/writing-samples")
+      .send({ domain: "nonfiction", text: "A body of text." });
+
+    expect(res.status).toBe(201);
+    const body = unwrap<{ filename: string | null }>(res);
+    expect(body.filename).toBeNull();
+  });
+});

--- a/tests/server/routes/writing-samples-create.test.ts
+++ b/tests/server/routes/writing-samples-create.test.ts
@@ -35,9 +35,7 @@ describe("POST /api/writing-samples", () => {
   });
 
   it("accepts a missing filename (defaults to null)", async () => {
-    const res = await request(app)
-      .post("/api/writing-samples")
-      .send({ domain: "nonfiction", text: "A body of text." });
+    const res = await request(app).post("/api/writing-samples").send({ domain: "nonfiction", text: "A body of text." });
 
     expect(res.status).toBe(201);
     const body = unwrap<{ filename: string | null }>(res);

--- a/tests/server/routes/writing-samples-delete.test.ts
+++ b/tests/server/routes/writing-samples-delete.test.ts
@@ -1,0 +1,35 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as writingSampleRepo from "../../../server/db/repositories/writing-samples.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeWritingSample } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("DELETE /api/writing-samples/:id", () => {
+  it("returns 204 and removes the sample on success", async () => {
+    const sample = makeWritingSample({ id: "to-delete" });
+    writingSampleRepo.createWritingSampleRecord(db, sample);
+
+    const res = await request(app).delete("/api/writing-samples/to-delete");
+    expect(res.status).toBe(204);
+    // RFC 7230: 204 responses MUST have an empty body.
+    expect(res.text).toBe("");
+    expect(writingSampleRepo.getWritingSample(db, "to-delete")).toBeNull();
+  });
+
+  it("returns 404 when the sample does not exist", async () => {
+    const res = await request(app).delete("/api/writing-samples/nonexistent");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("not found");
+  });
+});

--- a/tests/server/routes/writing-samples-list.test.ts
+++ b/tests/server/routes/writing-samples-list.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import * as writingSampleRepo from "../../../server/db/repositories/writing-samples.js";
+import { makeApiTestApp } from "../../helpers/apiTestApp.js";
+import { makeWritingSample } from "../../helpers/serverFactories.js";
+import { silenceConsole } from "../../helpers/silenceConsole.js";
+import { unwrap } from "../../helpers/unwrap.js";
+
+let app: ReturnType<typeof makeApiTestApp>["app"];
+let db: ReturnType<typeof makeApiTestApp>["db"];
+
+beforeEach(() => {
+  silenceConsole();
+  const testApp = makeApiTestApp();
+  app = testApp.app;
+  db = testApp.db;
+});
+
+describe("GET /api/writing-samples", () => {
+  it("returns [] when no samples exist", async () => {
+    const res = await request(app).get("/api/writing-samples");
+    expect(res.status).toBe(200);
+    const body = unwrap<unknown[]>(res);
+    expect(body).toEqual([]);
+  });
+
+  it("lists stored writing samples", async () => {
+    const sample = makeWritingSample({ id: "s1" });
+    writingSampleRepo.createWritingSampleRecord(db, sample);
+
+    const res = await request(app).get("/api/writing-samples");
+    expect(res.status).toBe(200);
+    const body = unwrap<Array<{ id: string }>>(res);
+    expect(body).toHaveLength(1);
+    expect(body[0]!.id).toBe("s1");
+  });
+});

--- a/tests/store/generation.test.ts
+++ b/tests/store/generation.test.ts
@@ -1,0 +1,426 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the LLM client module BEFORE importing anything that imports it.
+// CRITICAL (review E-C2): fetchModels MUST be stubbed too -- ProjectStore's
+// constructor calls it unconditionally.
+const generateStream = vi.fn();
+const callLLM = vi.fn();
+const fetchModels = vi.fn().mockResolvedValue([]);
+vi.mock("../../src/llm/client.js", () => ({
+  fetchModels: (...args: unknown[]) => fetchModels(...args),
+  generateStream: (...args: unknown[]) => generateStream(...args),
+  callLLM: (...args: unknown[]) => callLLM(...args),
+}));
+
+// Mock the auditor so we don't need a real bible.
+vi.mock("../../src/auditor/index.js", () => ({
+  runAudit: vi.fn(() => ({ flags: [], metrics: null })),
+  checkKillList: vi.fn(() => []),
+}));
+vi.mock("../../src/auditor/setupReconciler.js", () => ({
+  reconcileSetupStatuses: vi.fn((_bible: unknown, _irs: unknown, _orders: unknown, _ids: unknown) => ({
+    updatedBible: {},
+    changes: [],
+  })),
+}));
+vi.mock("../../src/auditor/subtext.js", () => ({
+  checkSubtext: vi.fn(() => []),
+}));
+
+import { createGenerationActions } from "../../src/app/store/generation.svelte.js";
+import { ProjectStore } from "../../src/app/store/project.svelte.js";
+import { makeChunk, makeScenePlan } from "../../src/app/stories/factories.js";
+import { createEmptyBible } from "../../src/types/index.js";
+
+function makeCommands() {
+  return {
+    saveBible: vi.fn().mockResolvedValue({ ok: true }),
+    saveScenePlan: vi.fn().mockResolvedValue({ ok: true }),
+    updateScenePlan: vi.fn().mockResolvedValue({ ok: true }),
+    saveMultipleScenePlans: vi.fn().mockResolvedValue({ ok: true }),
+    saveChapterArc: vi.fn().mockResolvedValue({ ok: true }),
+    updateChapterArc: vi.fn().mockResolvedValue({ ok: true }),
+    saveChunk: vi.fn().mockResolvedValue({ ok: true }),
+    updateChunk: vi.fn().mockResolvedValue({ ok: true }),
+    persistChunk: vi.fn().mockResolvedValue({ ok: true }),
+    removeChunk: vi.fn().mockResolvedValue({ ok: true }),
+    deleteChunk: vi.fn().mockResolvedValue({ ok: true }),
+    completeScene: vi.fn().mockResolvedValue({ ok: true }),
+    saveSceneIR: vi.fn().mockResolvedValue({ ok: true }),
+    verifySceneIR: vi.fn().mockResolvedValue({ ok: true }),
+    saveAuditFlags: vi.fn().mockResolvedValue({ ok: true }),
+    resolveAuditFlag: vi.fn().mockResolvedValue({ ok: true }),
+    dismissAuditFlag: vi.fn().mockResolvedValue({ ok: true }),
+    saveCompilationLog: vi.fn().mockResolvedValue({ ok: true }),
+    applyRefinement: vi.fn().mockResolvedValue({ ok: true }),
+  } as any;
+}
+
+function makeStoreWithScene(): ProjectStore {
+  const store = new ProjectStore();
+  store.setProject({ id: "p1", title: "t", status: "drafting", createdAt: "", updatedAt: "" });
+  store.setBible(createEmptyBible("p1"));
+  store.setScenes([{ plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 0 }]);
+  store.setActiveScene(0);
+  // Minimal compiled payload so generation can read model/temperature/topP.
+  store.setCompiled(
+    {
+      systemMessage: "sys",
+      userMessage: "user",
+      model: "claude-test",
+      temperature: 0.8,
+      topP: 0.92,
+      maxTokens: 1000,
+    } as any,
+    null,
+    null,
+  );
+  return store;
+}
+
+describe("createGenerationActions", () => {
+  beforeEach(() => {
+    generateStream.mockReset();
+    callLLM.mockReset();
+    fetchModels.mockClear();
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  // --- generateChunk ---
+
+  describe("generateChunk", () => {
+    it("sets store.error and removes pending chunk when onError fires", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      const actions = createGenerationActions(store, commands);
+      generateStream.mockImplementation(async (_p: unknown, h: { onError: (e: string) => void }) =>
+        h.onError("llm failure"),
+      );
+      await actions.generateChunk();
+      expect(store.error).toContain("Generation failed");
+      expect(commands.saveChunk).not.toHaveBeenCalled();
+      expect(store.activeSceneChunks).toHaveLength(0);
+    });
+
+    it("treats onDone with empty text and stop reason max_tokens as an error", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      const actions = createGenerationActions(store, commands);
+      generateStream.mockImplementation(async (_p: unknown, h: { onDone: (u: unknown, r: string) => void }) =>
+        h.onDone({}, "max_tokens"),
+      );
+      await actions.generateChunk();
+      expect(store.error).toContain("Empty generation");
+      expect(commands.saveChunk).not.toHaveBeenCalled();
+      expect(store.activeSceneChunks).toHaveLength(0);
+    });
+
+    it("persists the chunk and runs audit on happy-path onDone", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      const actions = createGenerationActions(store, commands);
+      generateStream.mockImplementation(
+        async (_p: unknown, h: { onToken: (t: string) => void; onDone: (u: unknown, r: string) => void }) => {
+          h.onToken("Hello ");
+          h.onToken("world.");
+          h.onDone({}, "end_turn");
+        },
+      );
+      await actions.generateChunk();
+      expect(commands.saveChunk).toHaveBeenCalledTimes(1);
+      expect(commands.saveAuditFlags).toHaveBeenCalledTimes(1);
+      expect(store.activeSceneChunks[0]!.generatedText).toBe("Hello world.");
+      expect(store.error).toBeNull();
+    });
+
+    it("removes pending chunk on AbortError and does not set error", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      const actions = createGenerationActions(store, commands);
+      generateStream.mockImplementation(async () => {
+        throw new DOMException("aborted", "AbortError");
+      });
+      await actions.generateChunk();
+      expect(store.activeSceneChunks).toHaveLength(0);
+      expect(store.error).toBeNull();
+      expect(commands.saveChunk).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- runAuditManual ---
+
+  describe("runAuditManual", () => {
+    it("sets error when bible is missing", async () => {
+      const store = makeStoreWithScene();
+      store.setBible(null);
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAuditManual();
+      expect(store.error).toContain("missing bible");
+      expect(commands.saveAuditFlags).not.toHaveBeenCalled();
+    });
+
+    it("sets error when the active scene has no chunks", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAuditManual();
+      expect(store.error).toContain("no chunks");
+      expect(commands.saveAuditFlags).not.toHaveBeenCalled();
+    });
+
+    it("runs audit and persists flags on happy path", async () => {
+      const store = makeStoreWithScene();
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0 })]);
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAuditManual();
+      expect(commands.saveAuditFlags).toHaveBeenCalledTimes(1);
+      expect(store.auditFlags).toEqual([]);
+    });
+  });
+
+  // --- runDeepAudit ---
+
+  describe("runDeepAudit", () => {
+    it("sets error when bible is missing", async () => {
+      const store = makeStoreWithScene();
+      store.setBible(null);
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runDeepAudit();
+      expect(store.error).toContain("missing bible");
+    });
+
+    it("sets error when the active scene has no chunks", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runDeepAudit();
+      expect(store.error).toContain("no chunks");
+    });
+
+    it("toggles isAuditing and persists combined flags on happy path", async () => {
+      const store = makeStoreWithScene();
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0 })]);
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runDeepAudit();
+      expect(commands.saveAuditFlags).toHaveBeenCalledTimes(1);
+      expect(store.isAuditing).toBe(false);
+    });
+  });
+
+  // --- extractSceneIR ---
+
+  describe("extractSceneIR", () => {
+    it("sets error when no active scene plan", async () => {
+      const store = new ProjectStore();
+      store.setBible(createEmptyBible("p1"));
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).extractSceneIR();
+      expect(store.error).toContain("no active scene plan");
+      expect(callLLM).not.toHaveBeenCalled();
+    });
+
+    it("sets error when there are no chunks", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).extractSceneIR();
+      expect(store.error).toContain("no chunks");
+    });
+
+    it("sets error when all chunks are empty prose", async () => {
+      const store = makeStoreWithScene();
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0, generatedText: "   " })]);
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).extractSceneIR();
+      expect(store.error).toContain("all chunks are empty");
+    });
+
+    it("happy path: saves IR, reconciles setups, opens inspector", async () => {
+      const store = makeStoreWithScene();
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0, generatedText: "Real prose here." })]);
+      // extractIR under the hood delegates to callLLM -- return a minimal IR-shaped JSON.
+      // Must have at least one non-empty array so rawToNarrativeIR doesn't throw.
+      callLLM.mockResolvedValue(
+        JSON.stringify({
+          sceneId: "s1",
+          events: ["something happened"],
+          characterDeltas: [],
+          setupsPlanted: [],
+          payoffsExecuted: [],
+          factsIntroduced: [],
+          factsRevealedToReader: [],
+          factsWithheld: [],
+          characterPositions: {},
+          unresolvedTensions: [],
+          verified: false,
+        }),
+      );
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).extractSceneIR();
+      expect(callLLM).toHaveBeenCalled();
+      expect(commands.saveSceneIR).toHaveBeenCalledTimes(1);
+      expect(store.irInspectorOpen).toBe(true);
+    });
+  });
+
+  // --- runAutopilot ---
+
+  describe("runAutopilot", () => {
+    it("sets error when no active scene plan / payload / bible", async () => {
+      const store = new ProjectStore();
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAutopilot();
+      expect(store.error).toContain("missing scene plan");
+    });
+
+    it("stops iteration when autopilotCancelled is set mid-loop", async () => {
+      const store = makeStoreWithScene();
+      const plan = makeScenePlan({ id: "s1", chunkCount: 5 });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.compilationConfig = { ...store.compilationConfig, autopilotMaxChunks: 20 };
+
+      // Cancel after the first chunk is generated.
+      let callCount = 0;
+      generateStream.mockImplementation(
+        async (_p: unknown, h: { onToken: (t: string) => void; onDone: (u: unknown, r: string) => void }) => {
+          callCount++;
+          h.onToken("body");
+          h.onDone({}, "end_turn");
+          // Cancel after first iteration completes
+          if (callCount >= 1) {
+            store.autopilotCancelled = true;
+          }
+        },
+      );
+
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAutopilot();
+      // Should have stopped after 1 chunk due to cancellation, not all 5.
+      expect(store.sceneChunks.s1!.length).toBeLessThanOrEqual(2);
+      expect(commands.completeScene).not.toHaveBeenCalled();
+    });
+
+    // REGRESSION GUARD for PR #68.
+    // Scene wants 5 chunks, cap is 2 -> generate exactly 2 and do NOT finalize.
+    it("honors autopilotMaxChunks cap and skips finalize when willCompleteScene=false", async () => {
+      const store = makeStoreWithScene();
+      const plan = makeScenePlan({ id: "s1", chunkCount: 5 });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.compilationConfig = { ...store.compilationConfig, autopilotMaxChunks: 2 };
+
+      generateStream.mockImplementation(
+        async (_p: unknown, h: { onToken: (t: string) => void; onDone: (u: unknown, r: string) => void }) => {
+          h.onToken("chunk body");
+          h.onDone({}, "end_turn");
+        },
+      );
+
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAutopilot();
+
+      // Exactly 2 chunks created this run.
+      expect(store.sceneChunks.s1).toHaveLength(2);
+      // Cap hit -> finalize skipped.
+      expect(commands.completeScene).not.toHaveBeenCalled();
+      expect(commands.saveSceneIR).not.toHaveBeenCalled();
+      expect(store.isAutopilot).toBe(false);
+    });
+
+    it("finalizes (completeScene + IR extraction) when run fulfills scene target", async () => {
+      const store = makeStoreWithScene();
+      const plan = makeScenePlan({ id: "s1", chunkCount: 2 });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.compilationConfig = { ...store.compilationConfig, autopilotMaxChunks: 20 };
+
+      generateStream.mockImplementation(
+        async (_p: unknown, h: { onToken: (t: string) => void; onDone: (u: unknown, r: string) => void }) => {
+          h.onToken("body");
+          h.onDone({}, "end_turn");
+        },
+      );
+      callLLM.mockResolvedValue(
+        JSON.stringify({
+          sceneId: "s1",
+          events: ["something happened"],
+          characterDeltas: [],
+          setupsPlanted: [],
+          payoffsExecuted: [],
+          factsIntroduced: [],
+          factsRevealedToReader: [],
+          factsWithheld: [],
+          characterPositions: {},
+          unresolvedTensions: [],
+          verified: false,
+        }),
+      );
+
+      const commands = makeCommands();
+      await createGenerationActions(store, commands).runAutopilot();
+
+      expect(store.sceneChunks.s1).toHaveLength(2);
+      expect(commands.completeScene).toHaveBeenCalledTimes(1);
+      expect(commands.saveSceneIR).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --- requestRefinement ---
+
+  describe("requestRefinement", () => {
+    const baseReq = {
+      sceneId: "s1",
+      selectedText: "Hello",
+      selectionStart: 0,
+      selectionEnd: 5,
+      instruction: "tighten",
+      chips: [],
+    };
+
+    it("returns null and sets error when bible is missing", async () => {
+      const store = makeStoreWithScene();
+      store.setBible(null);
+      const commands = makeCommands();
+      const res = await createGenerationActions(store, commands).requestRefinement(baseReq);
+      expect(res).toBeNull();
+      expect(store.error).toContain("missing bible");
+    });
+
+    it("returns null when the scene has no chunks", async () => {
+      const store = makeStoreWithScene();
+      const commands = makeCommands();
+      const res = await createGenerationActions(store, commands).requestRefinement(baseReq);
+      expect(res).toBeNull();
+      expect(store.error).toContain("no chunks");
+    });
+
+    it("returns null and surfaces parse error when variants are empty", async () => {
+      const store = makeStoreWithScene();
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0 })]);
+      callLLM.mockResolvedValue("not json at all");
+      const commands = makeCommands();
+      const res = await createGenerationActions(store, commands).requestRefinement(baseReq);
+      expect(res).toBeNull();
+      expect(store.error).not.toBeNull();
+    });
+
+    it("returns a RefinementResult on happy path", async () => {
+      const store = makeStoreWithScene();
+      store.setSceneChunks("s1", [
+        makeChunk({ sceneId: "s1", sequenceNumber: 0, generatedText: "Hello world text here." }),
+      ]);
+      callLLM.mockResolvedValue(
+        JSON.stringify({
+          variants: [{ text: "Refined text.", rationale: "tighter" }],
+        }),
+      );
+      const commands = makeCommands();
+      const res = await createGenerationActions(store, commands).requestRefinement(baseReq);
+      expect(res).not.toBeNull();
+      expect(res!.variants.length).toBeGreaterThan(0);
+      expect(res!.requestedAt).toBeDefined();
+      expect(res!.completedAt).toBeDefined();
+    });
+  });
+});

--- a/tests/store/project.test.ts
+++ b/tests/store/project.test.ts
@@ -10,12 +10,7 @@ vi.mock("../../src/llm/client.js", () => ({
 }));
 
 import { ProjectStore } from "../../src/app/store/project.svelte.js";
-import {
-  makeAuditFlag,
-  makeChunk,
-  makeNarrativeIR,
-  makeScenePlan,
-} from "../../src/app/stories/factories.js";
+import { makeAuditFlag, makeChunk, makeNarrativeIR, makeScenePlan } from "../../src/app/stories/factories.js";
 import { createDefaultCompilationConfig, createEmptyBible } from "../../src/types/index.js";
 
 describe("ProjectStore", () => {
@@ -298,16 +293,12 @@ describe("ProjectStore", () => {
     });
 
     it("setEditorialAnnotations and getEditorialAnnotations round-trip", () => {
-      store.setEditorialAnnotations("s1", 0, [
-        // biome-ignore lint/suspicious/noExplicitAny: minimal annotation shape
-        { id: "a1", chunkIndex: 0, comment: "nice" } as any,
-      ]);
+      store.setEditorialAnnotations("s1", 0, [{ id: "a1", chunkIndex: 0, comment: "nice" } as any]);
       const anns = store.getEditorialAnnotations("s1");
       expect(anns.get(0)).toHaveLength(1);
     });
 
     it("clearEditorialAnnotations removes the scene's annotations", () => {
-      // biome-ignore lint/suspicious/noExplicitAny: annotation shape
       store.setEditorialAnnotations("s1", 0, [{ id: "a1" } as any]);
       store.clearEditorialAnnotations("s1");
       expect(store.getEditorialAnnotations("s1").size).toBe(0);
@@ -396,7 +387,6 @@ describe("ProjectStore", () => {
 
   describe("setCompiled", () => {
     it("stores compiled payload, log, and lint together", () => {
-      // biome-ignore lint/suspicious/noExplicitAny: partial fixtures for this store-level test
       store.setCompiled({ systemMessage: "s", userMessage: "u" } as any, { steps: [] } as any, { issues: [] } as any);
       expect(store.compiledPayload).not.toBeNull();
       expect(store.compilationLog).not.toBeNull();
@@ -419,7 +409,6 @@ describe("ProjectStore", () => {
 
   describe("voice guide setters", () => {
     it("setVoiceGuide / setProjectVoiceGuide store and clear", () => {
-      // biome-ignore lint/suspicious/noExplicitAny: minimal guide
       const g = { version: 1, createdAt: "", ring1Injection: "x" } as any;
       store.setVoiceGuide(g);
       expect(store.voiceGuide).toEqual(g);
@@ -432,7 +421,6 @@ describe("ProjectStore", () => {
 
   describe("setChapterArc", () => {
     it("stores and clears the chapter arc", () => {
-      // biome-ignore lint/suspicious/noExplicitAny: minimal arc
       const arc = { id: "a1", title: "Ch1" } as any;
       store.setChapterArc(arc);
       expect(store.chapterArc).toEqual(arc);

--- a/tests/store/project.test.ts
+++ b/tests/store/project.test.ts
@@ -1,0 +1,494 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// CRITICAL (review E-C2): ProjectStore's constructor calls fetchModels()
+// from src/llm/client.js. Without this mock, every `new ProjectStore()`
+// call crashes with `TypeError: fetchModels is not a function`.
+vi.mock("../../src/llm/client.js", () => ({
+  fetchModels: vi.fn().mockResolvedValue([]),
+  generateStream: vi.fn(),
+  callLLM: vi.fn(),
+}));
+
+import { ProjectStore } from "../../src/app/store/project.svelte.js";
+import {
+  makeAuditFlag,
+  makeChunk,
+  makeNarrativeIR,
+  makeScenePlan,
+} from "../../src/app/stories/factories.js";
+import { createDefaultCompilationConfig, createEmptyBible } from "../../src/types/index.js";
+
+describe("ProjectStore", () => {
+  let store: ProjectStore;
+
+  beforeEach(() => {
+    store = new ProjectStore();
+  });
+
+  describe("setProject", () => {
+    it("stores the project", () => {
+      store.setProject({ id: "p1", title: "X", status: "drafting", createdAt: "", updatedAt: "" });
+      expect(store.project?.id).toBe("p1");
+    });
+
+    it("accepts null to clear", () => {
+      store.setProject({ id: "p1", title: "X", status: "drafting", createdAt: "", updatedAt: "" });
+      store.setProject(null);
+      expect(store.project).toBeNull();
+    });
+  });
+
+  describe("setBible / setChapterArc / setVoiceGuide", () => {
+    it("round-trips bible", () => {
+      const bible = createEmptyBible("p1");
+      store.setBible(bible);
+      expect(store.bible).toEqual(bible);
+    });
+  });
+
+  describe("scenes and active scene", () => {
+    it("exposes the active scene plan via the getter", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      expect(store.activeScenePlan?.id).toBe("s1");
+    });
+
+    it("returns null for activeScene when no scenes exist", () => {
+      expect(store.activeScene).toBeNull();
+      expect(store.activeScenePlan).toBeNull();
+    });
+
+    it("addMultipleScenePlans appends entries", () => {
+      store.addMultipleScenePlans([makeScenePlan(), makeScenePlan()]);
+      expect(store.scenes).toHaveLength(2);
+    });
+
+    it("updateSceneStatus mutates the matching scene", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.updateSceneStatus("s1", "complete");
+      expect(store.scenes[0]!.status).toBe("complete");
+    });
+  });
+
+  describe("scene chunks", () => {
+    it("setSceneChunks replaces the per-scene chunk list", () => {
+      const c1 = makeChunk({ sceneId: "s1", sequenceNumber: 0 });
+      store.setSceneChunks("s1", [c1]);
+      expect(store.sceneChunks.s1).toHaveLength(1);
+    });
+
+    it("addChunk appends to the active scene", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.addChunk(makeChunk({ sceneId: "s1", sequenceNumber: 0 }));
+      expect(store.activeSceneChunks).toHaveLength(1);
+    });
+
+    it("updateChunkForScene mutates the chunk at the given index", () => {
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0 })]);
+      store.updateChunkForScene("s1", 0, { status: "accepted" });
+      expect(store.sceneChunks.s1![0]!.status).toBe("accepted");
+    });
+
+    it("removeChunkForScene drops the chunk at the given index", () => {
+      store.setSceneChunks("s1", [
+        makeChunk({ sceneId: "s1", sequenceNumber: 0 }),
+        makeChunk({ sceneId: "s1", sequenceNumber: 1 }),
+      ]);
+      store.removeChunkForScene("s1", 0);
+      expect(store.sceneChunks.s1).toHaveLength(1);
+    });
+  });
+
+  describe("previousSceneLastChunk", () => {
+    it("returns null when active scene is the first", () => {
+      store.setScenes([{ plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      expect(store.previousSceneLastChunk).toBeNull();
+    });
+
+    it("returns the last chunk of the prior scene when index > 0", () => {
+      const prev = makeChunk({ sceneId: "s0", sequenceNumber: 1, generatedText: "prev text" });
+      store.setScenes([
+        { plan: makeScenePlan({ id: "s0" }), status: "complete", sceneOrder: 0 },
+        { plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 1 },
+      ]);
+      store.setSceneChunks("s0", [makeChunk({ sceneId: "s0", sequenceNumber: 0 }), prev]);
+      store.setActiveScene(1);
+      expect(store.previousSceneLastChunk?.generatedText).toBe("prev text");
+    });
+  });
+
+  describe("scene IRs", () => {
+    it("setSceneIR stores the IR", () => {
+      const ir = makeNarrativeIR();
+      store.setSceneIR("s1", ir);
+      expect(store.sceneIRs.s1).toEqual(ir);
+    });
+
+    it("verifySceneIR marks the stored IR as verified", () => {
+      store.setSceneIR("s1", makeNarrativeIR({ verified: false }));
+      store.verifySceneIR("s1");
+      expect(store.sceneIRs.s1!.verified).toBe(true);
+    });
+
+    it("previousSceneIRs returns IRs from scenes before the active one", () => {
+      store.setScenes([
+        { plan: makeScenePlan({ id: "s0" }), status: "complete", sceneOrder: 0 },
+        { plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 1 },
+      ]);
+      store.setSceneIR("s0", makeNarrativeIR());
+      store.setActiveScene(1);
+      expect(store.previousSceneIRs).toHaveLength(1);
+    });
+  });
+
+  describe("audit flags", () => {
+    it("setAudit replaces flags and metrics", () => {
+      store.setAudit([], null);
+      expect(store.auditFlags).toEqual([]);
+      expect(store.metrics).toBeNull();
+    });
+
+    // Review E-C1: use makeAuditFlag factory -- it already uses the canonical
+    // hyphen form `category: "kill-list"` (NOT `"kill_list"`).
+    it("resolveAuditFlag sets resolved and wasActionable on the matching flag", () => {
+      store.setAudit([makeAuditFlag({ id: "f1", sceneId: "s1" })], null);
+      store.resolveAuditFlag("f1", "fixed", true);
+      expect(store.auditFlags[0]!.resolved).toBe(true);
+      expect(store.auditFlags[0]!.resolvedAction).toBe("fixed");
+      expect(store.auditFlags[0]!.wasActionable).toBe(true);
+    });
+
+    it("dismissAuditFlag marks the flag resolved and non-actionable", () => {
+      store.setAudit([makeAuditFlag({ id: "f1", sceneId: "s1" })], null);
+      store.dismissAuditFlag("f1");
+      expect(store.auditFlags[0]!.resolved).toBe(true);
+      expect(store.auditFlags[0]!.wasActionable).toBe(false);
+    });
+  });
+
+  describe("error and selection", () => {
+    it("setError stores the error message", () => {
+      store.setError("boom");
+      expect(store.error).toBe("boom");
+      store.setError(null);
+      expect(store.error).toBeNull();
+    });
+
+    it("selectChunk stores the selected index", () => {
+      store.selectChunk(3);
+      expect(store.selectedChunkIndex).toBe(3);
+      store.selectChunk(null);
+      expect(store.selectedChunkIndex).toBeNull();
+    });
+  });
+
+  // --- Added per review E-C3: missing public-API coverage ---
+
+  describe("loadFromServer", () => {
+    it("populates project, bible, scenes, chunks, IRs, versions, voice guides", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      const chunk = makeChunk({ sceneId: "s1", sequenceNumber: 0 });
+      const ir = makeNarrativeIR();
+      store.loadFromServer({
+        project: { id: "p1", title: "t", status: "drafting", createdAt: "", updatedAt: "" },
+        bible: createEmptyBible("p1"),
+        chapterArc: null,
+        scenes: [{ plan, status: "drafting", sceneOrder: 0 }],
+        sceneChunks: { s1: [chunk] },
+        sceneIRs: { s1: ir },
+        bibleVersions: [{ version: 1, createdAt: "2024-01-01T00:00:00Z" }],
+        voiceGuide: null,
+        projectVoiceGuide: null,
+      });
+      expect(store.project?.id).toBe("p1");
+      expect(store.scenes).toHaveLength(1);
+      expect(store.sceneChunks.s1).toHaveLength(1);
+      expect(store.sceneIRs.s1).toEqual(ir);
+      expect(store.bibleVersions).toHaveLength(1);
+      expect(store.error).toBeNull();
+    });
+
+    it("defaults projectVoiceGuide to null when omitted", () => {
+      store.loadFromServer({
+        project: { id: "p", title: "", status: "drafting", createdAt: "", updatedAt: "" },
+        bible: null,
+        chapterArc: null,
+        scenes: [],
+        sceneChunks: {},
+        sceneIRs: {},
+        bibleVersions: [],
+        voiceGuide: null,
+      });
+      expect(store.projectVoiceGuide).toBeNull();
+    });
+  });
+
+  describe("resetForProjectSwitch", () => {
+    it("clears all project-scoped state back to defaults", () => {
+      store.setProject({ id: "p1", title: "t", status: "drafting", createdAt: "", updatedAt: "" });
+      store.setBible(createEmptyBible("p1"));
+      store.setScenes([{ plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 0 }]);
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0 })]);
+      store.setError("boom");
+      store.resetForProjectSwitch();
+      expect(store.project).toBeNull();
+      expect(store.bible).toBeNull();
+      expect(store.scenes).toEqual([]);
+      expect(store.sceneChunks).toEqual({});
+      expect(store.sceneIRs).toEqual({});
+      expect(store.auditFlags).toEqual([]);
+      expect(store.error).toBeNull();
+      expect(store.isGenerating).toBe(false);
+      expect(store.isAutopilot).toBe(false);
+    });
+  });
+
+  describe("addScenePlan and setScenePlan", () => {
+    it("addScenePlan appends a new plan and makes it active", () => {
+      store.addScenePlan(makeScenePlan({ id: "s1" }));
+      store.addScenePlan(makeScenePlan({ id: "s2" }));
+      expect(store.scenes).toHaveLength(2);
+      expect(store.activeSceneIndex).toBe(1);
+    });
+
+    it("addScenePlan replaces a scene with the same id in place", () => {
+      const first = makeScenePlan({ id: "s1", title: "first" });
+      const replacement = makeScenePlan({ id: "s1", title: "replaced" });
+      store.addScenePlan(first);
+      store.addScenePlan(replacement);
+      expect(store.scenes).toHaveLength(1);
+      expect(store.scenes[0]!.plan.title).toBe("replaced");
+    });
+
+    it("setScenePlan(null) clears scenes", () => {
+      store.setScenePlan(makeScenePlan({ id: "s1" }));
+      store.setScenePlan(null);
+      expect(store.scenes).toEqual([]);
+      expect(store.activeSceneIndex).toBe(0);
+    });
+
+    it("setScenePlan(plan) replaces scenes with a single entry", () => {
+      store.setScenePlan(makeScenePlan({ id: "s1" }));
+      expect(store.scenes).toHaveLength(1);
+      expect(store.scenes[0]!.plan.id).toBe("s1");
+    });
+  });
+
+  describe("completeScene", () => {
+    it("marks the matching scene as complete", () => {
+      store.setScenes([
+        { plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 0 },
+        { plan: makeScenePlan({ id: "s2" }), status: "drafting", sceneOrder: 1 },
+      ]);
+      store.completeScene("s1");
+      expect(store.scenes[0]!.status).toBe("complete");
+      expect(store.scenes[1]!.status).toBe("drafting");
+    });
+  });
+
+  describe("setBibleVersions / setEditorialAnnotations / setExtractingIR", () => {
+    it("setBibleVersions stores version list", () => {
+      store.setBibleVersions([{ version: 1, createdAt: "2024-01-01" }]);
+      expect(store.bibleVersions).toHaveLength(1);
+    });
+
+    it("setEditorialAnnotations and getEditorialAnnotations round-trip", () => {
+      store.setEditorialAnnotations("s1", 0, [
+        // biome-ignore lint/suspicious/noExplicitAny: minimal annotation shape
+        { id: "a1", chunkIndex: 0, comment: "nice" } as any,
+      ]);
+      const anns = store.getEditorialAnnotations("s1");
+      expect(anns.get(0)).toHaveLength(1);
+    });
+
+    it("clearEditorialAnnotations removes the scene's annotations", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: annotation shape
+      store.setEditorialAnnotations("s1", 0, [{ id: "a1" } as any]);
+      store.clearEditorialAnnotations("s1");
+      expect(store.getEditorialAnnotations("s1").size).toBe(0);
+    });
+
+    it("setExtractingIR updates extractingIRSceneId and isExtractingIR derives correctly", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      expect(store.isExtractingIR).toBe(false);
+      store.setExtractingIR("s1");
+      expect(store.extractingIRSceneId).toBe("s1");
+      expect(store.isExtractingIR).toBe(true);
+      store.setExtractingIR(null);
+      expect(store.isExtractingIR).toBe(false);
+    });
+  });
+
+  describe("activeSceneIR", () => {
+    it("returns null when no IR is stored for the active scene", () => {
+      store.setScenes([{ plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      expect(store.activeSceneIR).toBeNull();
+    });
+
+    it("returns the stored IR for the active scene", () => {
+      const ir = makeNarrativeIR();
+      store.setScenes([{ plan: makeScenePlan({ id: "s1" }), status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.setSceneIR("s1", ir);
+      expect(store.activeSceneIR).toEqual(ir);
+    });
+  });
+
+  describe("cancelGeneration / cancelAutopilot / setGenerating / setAutopilot", () => {
+    it("setGenerating(true) creates an AbortController; (false) clears it", () => {
+      store.setGenerating(true);
+      expect(store.isGenerating).toBe(true);
+      expect(store.generationAbortController).not.toBeNull();
+      store.setGenerating(false);
+      expect(store.generationAbortController).toBeNull();
+    });
+
+    it("cancelGeneration aborts the in-flight controller without flipping isGenerating", () => {
+      store.setGenerating(true);
+      const ctrl = store.generationAbortController!;
+      store.cancelGeneration();
+      expect(ctrl.signal.aborted).toBe(true);
+      // isGenerating stays true -- the finally block in generateChunk clears it.
+      expect(store.isGenerating).toBe(true);
+    });
+
+    it("setAutopilot(true) resets autopilotCancelled", () => {
+      store.autopilotCancelled = true;
+      store.setAutopilot(true);
+      expect(store.isAutopilot).toBe(true);
+      expect(store.autopilotCancelled).toBe(false);
+    });
+
+    it("cancelAutopilot sets autopilotCancelled, clears isAutopilot, aborts stream", () => {
+      store.setAutopilot(true);
+      store.setGenerating(true);
+      const ctrl = store.generationAbortController!;
+      store.cancelAutopilot();
+      expect(store.autopilotCancelled).toBe(true);
+      expect(store.isAutopilot).toBe(false);
+      expect(ctrl.signal.aborted).toBe(true);
+    });
+  });
+
+  describe("selectModel", () => {
+    it("no-ops when model id is not in availableModels", () => {
+      const before = store.compilationConfig.defaultModel;
+      store.selectModel("nonexistent");
+      expect(store.compilationConfig.defaultModel).toBe(before);
+    });
+
+    it("updates defaultModel, modelContextWindow, and reservedForOutput when spec is found", () => {
+      store.setModels([{ id: "m1", label: "Model 1", contextWindow: 200_000, maxOutput: 4096 }]);
+      store.selectModel("m1");
+      expect(store.compilationConfig.defaultModel).toBe("m1");
+      expect(store.compilationConfig.modelContextWindow).toBe(200_000);
+      expect(store.compilationConfig.reservedForOutput).toBeLessThanOrEqual(4096);
+    });
+  });
+
+  describe("setCompiled", () => {
+    it("stores compiled payload, log, and lint together", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: partial fixtures for this store-level test
+      store.setCompiled({ systemMessage: "s", userMessage: "u" } as any, { steps: [] } as any, { issues: [] } as any);
+      expect(store.compiledPayload).not.toBeNull();
+      expect(store.compilationLog).not.toBeNull();
+      expect(store.lintResult).not.toBeNull();
+    });
+  });
+
+  describe("setConfig and setModels", () => {
+    it("setConfig replaces the compilation config", () => {
+      const cfg = createDefaultCompilationConfig();
+      store.setConfig(cfg);
+      expect(store.compilationConfig).toEqual(cfg);
+    });
+
+    it("setModels replaces the models list", () => {
+      store.setModels([{ id: "m1", label: "Model 1", contextWindow: 100, maxOutput: 50 }]);
+      expect(store.availableModels).toHaveLength(1);
+    });
+  });
+
+  describe("voice guide setters", () => {
+    it("setVoiceGuide / setProjectVoiceGuide store and clear", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal guide
+      const g = { version: 1, createdAt: "", ring1Injection: "x" } as any;
+      store.setVoiceGuide(g);
+      expect(store.voiceGuide).toEqual(g);
+      store.setVoiceGuide(null);
+      expect(store.voiceGuide).toBeNull();
+      store.setProjectVoiceGuide(g);
+      expect(store.projectVoiceGuide).toEqual(g);
+    });
+  });
+
+  describe("setChapterArc", () => {
+    it("stores and clears the chapter arc", () => {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal arc
+      const arc = { id: "a1", title: "Ch1" } as any;
+      store.setChapterArc(arc);
+      expect(store.chapterArc).toEqual(arc);
+      store.setChapterArc(null);
+      expect(store.chapterArc).toBeNull();
+    });
+  });
+
+  describe("updateChunk / removeChunk (active-scene wrappers)", () => {
+    it("updateChunk delegates to updateChunkForScene for the active scene", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.setSceneChunks("s1", [makeChunk({ sceneId: "s1", sequenceNumber: 0 })]);
+      store.updateChunk(0, { status: "accepted" });
+      expect(store.sceneChunks.s1![0]!.status).toBe("accepted");
+    });
+
+    it("updateChunk is a no-op when no scene is active", () => {
+      store.updateChunk(0, { status: "accepted" });
+      expect(store.sceneChunks).toEqual({});
+    });
+
+    it("removeChunk delegates to removeChunkForScene for the active scene", () => {
+      const plan = makeScenePlan({ id: "s1" });
+      store.setScenes([{ plan, status: "drafting", sceneOrder: 0 }]);
+      store.setActiveScene(0);
+      store.setSceneChunks("s1", [
+        makeChunk({ sceneId: "s1", sequenceNumber: 0 }),
+        makeChunk({ sceneId: "s1", sequenceNumber: 1 }),
+      ]);
+      store.removeChunk(0);
+      expect(store.sceneChunks.s1).toHaveLength(1);
+    });
+  });
+
+  describe("UI state setters", () => {
+    it("setBootstrapOpen / setBibleAuthoringOpen / setSceneAuthoringOpen / setIRInspectorOpen", () => {
+      store.setBootstrapOpen(true);
+      store.setBibleAuthoringOpen(true);
+      store.setSceneAuthoringOpen(true);
+      store.setIRInspectorOpen(true);
+      expect(store.bootstrapModalOpen).toBe(true);
+      expect(store.bibleAuthoringOpen).toBe(true);
+      expect(store.sceneAuthoringOpen).toBe(true);
+      expect(store.irInspectorOpen).toBe(true);
+    });
+
+    it("setAuditing / setReviewingChunks", () => {
+      store.setAuditing(true);
+      expect(store.isAuditing).toBe(true);
+      store.setReviewingChunks(new Set([1, 2]));
+      expect(store.reviewingChunks.size).toBe(2);
+    });
+  });
+
+  // loadFile / saveFile require a real DOM and are skipped here.
+  // TODO(#36 follow-up): exercise them in a jsdom-specific spec.
+});


### PR DESCRIPTION
## Summary
- Adds 11 new route test files covering the untested Anthropic-dependent and CRUD routes in `server/api/routes.ts` (voice-guide x3, writing-samples x3, significant-edits, cipher/batch, project-voice-guide x2, voice/redistill).
- Adds 2 new store test files covering `project.svelte.ts` (direct unit tests for full public API) and `generation.svelte.ts` (all 6 methods of `createGenerationActions` with error, edge, and happy-path branches).
- Adds 4 new helper files under `tests/helpers/`: `apiTestAppWithAnthropic.ts`, `unwrap.ts`, `silenceConsole.ts`, `serverFactories.ts`.
- **No source edits.** Everything lands under `tests/**` as new files.

## Coordination
- **Package B has NOT landed.** `unwrap.ts` uses the pre-envelope pass-through form. B's author owns updating `unwrap.ts` when they merge.
- **Package A has NOT landed.** `apiTestAppWithAnthropic.ts` has a `// TODO(#36/A follow-up):` comment at the top to mirror `runMigrations(db)` when A merges.
- All audit-flag fixtures use the canonical `"kill-list"` (hyphen) category, compatible with Package A's CHECK triggers.

## Scope notes
- Written against **current** API shapes. Package B (#29, #30) will change envelopes; per the [parallel batch design](../blob/main/docs/superpowers/specs/2026-04-15-p1-parallel-batch-design.md#L59-L70), the B author owns updating these assertions in the B PR.
- `server/profile/stage3.ts`, `stage4.ts`, `llm.ts` mentioned in #36 are **deferred** — they are pure modules best covered in a separate follow-up, and keeping this PR focused on routes + stores avoids scope creep.
- `loadFile`/`saveFile` on ProjectStore require a real DOM and are deferred with a `// TODO(#36 follow-up)` note.

## Test plan
- [x] `pnpm typecheck` green
- [x] `pnpm test` — 122 test files, 1551 tests passing
- [x] 11 new route test files all pass
- [x] 2 new store test files pass
- [x] No existing tests are modified
- [x] Biome check clean on new files

Resolves #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)